### PR TITLE
Remove create directory for Data/Fastq

### DIFF
--- a/sequence_processing_pipeline/SequenceDirectory.py
+++ b/sequence_processing_pipeline/SequenceDirectory.py
@@ -1,7 +1,6 @@
-import os
 from sequence_processing_pipeline.PipelineError import PipelineError
 from metapool import KLSampleSheet, validate_and_scrub_sample_sheet
-from os.path import join, exists
+from os.path import exists
 
 
 class SequenceDirectory:
@@ -24,17 +23,6 @@ class SequenceDirectory:
                                     "does not exist")
         else:
             raise PipelineError("An sample sheet must be supplied")
-
-        self.fastq_results_directory = join(self.sequence_directory, 'Data',
-                                            'Fastq')
-
-        try:
-            os.makedirs(self.fastq_results_directory, exist_ok=True)
-        except OSError as e:
-            # this is a known potential error. Re-raise it as a
-            # PipelineError, so it gets handled in the same location as the
-            # others.
-            raise PipelineError(str(e))
 
         sheet = KLSampleSheet(sample_sheet_path)
         valid_sheet = validate_and_scrub_sample_sheet(sheet)


### PR DESCRIPTION
Previouly it was assumed that the user would supply the path to a run-directory, and the data would be located in the sub-directory 'Data/Fastq'.
Since we expect now to be passed the directory containing the files itself, and we can expect that it's a read-only directory, we don't need this code anymore.