### PR TITLE
Wrap sample-sheet path in double-quotes.

### DIFF
--- a/sequence_processing_pipeline/ConvertJob.py
+++ b/sequence_processing_pipeline/ConvertJob.py
@@ -102,7 +102,7 @@ class ConvertJob(Job):
         # accordingly.
         if 'bcl-convert' in self.bcl_tool:
             lines.append(('%s '
-                          '--sample-sheet %s '
+                          '--sample-sheet "%s" '
                           '--output-directory %s '
                           '--bcl-input-directory . '
                           '--bcl-num-decompression-threads 16 '
@@ -117,7 +117,7 @@ class ConvertJob(Job):
             # equivalent cp for bcl-conversion (see below) needed.
         else:
             lines.append(('%s '
-                          '--sample-sheet %s '
+                          '--sample-sheet "%s" '
                           '--minimum-trimmed-read-length 1 '
                           '--mask-short-adapter-reads 1 '
                           '-R . '

--- a/sequence_processing_pipeline/GenPrepFileJob.py
+++ b/sequence_processing_pipeline/GenPrepFileJob.py
@@ -61,7 +61,7 @@ class GenPrepFileJob(Job):
         # heading.
         self.command = [self.seqpro_path,
                         join(self.output_path, self.run_id),
-                        self.sample_sheet_path,
+                        f'"{self.sample_sheet_path}"',
                         join(self.output_path, 'PrepFiles')]
 
     def run(self, callback=None):

--- a/sequence_processing_pipeline/tests/test_ConvertJob.py
+++ b/sequence_processing_pipeline/tests/test_ConvertJob.py
@@ -962,7 +962,7 @@ SCRIPT_EXP = ''.join([
     'date\n',
     'hostname\n',
     'cd {run_dir}\n',
-    'tests/bin/bcl-convert --sample-sheet {ssp}/good-sample-sheet.csv '
+    'tests/bin/bcl-convert --sample-sheet "{ssp}/good-sample-sheet.csv" '
     '--output-directory {gop}/ConvertJob '
     '--bcl-input-directory . '
     '--bcl-num-decompression-threads 16 --bcl-num-conversion-threads 16 '


### PR DESCRIPTION
Wrap sample-sheet path in double-quotes so bcl-convert doesn't break on sample-sheets with () in the name.
seqpro updated for good measure, but hasn't been known to break.