### PR TITLE
Fix read csv

### DIFF
--- a/sequence_processing_pipeline/Pipeline.py
+++ b/sequence_processing_pipeline/Pipeline.py
@@ -406,7 +406,7 @@ class Pipeline:
                'extractionkit_lot'}
 
         try:
-            df = pd.read_csv(mapping_file_path, delimiter='\t')
+            df = pd.read_csv(mapping_file_path, delimiter='\t', dtype=str)
 
             columns = [x.lower() for x in list(df.columns)]
             if len(set(columns)) < len(columns):

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -101,6 +101,7 @@ class TestPipeline(unittest.TestCase):
         df = pd.DataFrame(rows, columns=cols)
         buf = io.StringIO()
         df.to_csv(buf, sep='\t', index=False, header=True)
+        buf.seek(0)
         return buf
 
     def test_validate_mapping_file_numeric_ids(self):

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -96,8 +96,8 @@ class TestPipeline(unittest.TestCase):
                 'primer_plate', 'run_center', 'primer_date', 'target_gene',
                 'processing_robot', 'extractionkit_lot')
         rows = [['1.0', ], ['1e-3', ]]
-        rows[0].extend(['foo'] * len(cols))
-        rows[1].extend(['foo'] * len(cols))
+        rows[0].extend(['foo'] * (len(cols) - 1)
+        rows[1].extend(['foo'] * (len(cols) - 1)
         df = pd.DataFrame(rows, columns=cols)
         buf = io.StringIO()
         df.to_csv(buf, sep='\t', index=False, header=True)

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -1,4 +1,5 @@
 import json
+import io
 import os
 from sequence_processing_pipeline.PipelineError import PipelineError
 from sequence_processing_pipeline.Pipeline import Pipeline
@@ -82,6 +83,32 @@ class TestPipeline(unittest.TestCase):
         except FileNotFoundError:
             # make method idempotent
             pass
+
+    def _make_mapping_file()
+        cols = ('sample_name', 'barcode', 'library_construction_protocol',
+                'mastermix_lot', 'sample_plate', 'center_project_name',
+                'instrument_model', 'tm1000_8_tool', 'well_id', 'tm50_8_tool',
+                'well_description', 'run_prefix', 'run_date', 'center_name',
+                'tm300_8_tool', 'extraction_robot',
+                'experiment_design_description', 'platform', 'water_lot',
+                'project_name', 'pcr_primers', 'sequencing_meth', 'plating',
+                'orig_name', 'linker', 'runid', 'target_subfragment', 'primer',
+                'primer_plate', 'run_center', 'primer_date', 'target_gene',
+                'processing_robot', 'extractionkit_lot')
+        rows = [['1.0', ], ['1e-3', ]]
+        rows[0].extend(['foo'] * len(cols))
+        rows[1].extend(['foo'] * len(cols))
+        df = pd.DataFrame(rows, columns=cols)
+        buf = io.StringIO()
+        df.to_csv(buf, sep='\t', index=False, header=True)
+        return buf
+
+    def test_validate_mapping_file_numeric_ids(self):
+        buf = self._make_mapping_file()
+        exp = ['1.0', '1e-3']
+        obs_df = Pipeline._validate_mapping_file(buf)
+
+        self.assertEqual(list(obs_df['sample_name']), exp)
 
     def test_required_file_checks(self):
         # begin this test by deleting the RunInfo.txt file and verifying that

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -84,7 +84,7 @@ class TestPipeline(unittest.TestCase):
             # make method idempotent
             pass
 
-    def _make_mapping_file():
+    def _make_mapping_file(self):
         cols = ('sample_name', 'barcode', 'library_construction_protocol',
                 'mastermix_lot', 'sample_plate', 'center_project_name',
                 'instrument_model', 'tm1000_8_tool', 'well_id', 'tm50_8_tool',

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -84,7 +84,7 @@ class TestPipeline(unittest.TestCase):
             # make method idempotent
             pass
 
-    def _make_mapping_file()
+    def _make_mapping_file():
         cols = ('sample_name', 'barcode', 'library_construction_protocol',
                 'mastermix_lot', 'sample_plate', 'center_project_name',
                 'instrument_model', 'tm1000_8_tool', 'well_id', 'tm50_8_tool',

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -96,8 +96,8 @@ class TestPipeline(unittest.TestCase):
                 'primer_plate', 'run_center', 'primer_date', 'target_gene',
                 'processing_robot', 'extractionkit_lot')
         rows = [['1.0', ], ['1e-3', ]]
-        rows[0].extend(['foo'] * (len(cols) - 1)
-        rows[1].extend(['foo'] * (len(cols) - 1)
+        rows[0].extend(['foo'] * (len(cols) - 1))
+        rows[1].extend(['foo'] * (len(cols) - 1))
         df = pd.DataFrame(rows, columns=cols)
         buf = io.StringIO()
         df.to_csv(buf, sep='\t', index=False, header=True)


### PR DESCRIPTION
Adds an explicit test for numeric sample IDs with the parsing logic.

I don't have a full dev environment setup, so unfortunately need to rely on actions for exercising the test suite.

In reviewing the test code, I was surprised this method did not have explicit tests associated with it. There are a series of implicit ones, but it's more complex to untangle what is being asserted. 

Additionally, I saw that the code in `Pipeline` relies on testing the messages of exceptions, rather than differentiating exceptions. This is an important maintenance concern as an error message is much more likely to be modified than the exception object name, if that occurs the tests for the exception messages will silently stop working. And additionally, we have runtime support for `NameError` if an exception object name changes. This is noted in #93 