### PR TITLE
WIP Added locking on run_directories

### DIFF
--- a/sequence_processing_pipeline/configuration.json
+++ b/sequence_processing_pipeline/configuration.json
@@ -3,7 +3,8 @@
     "pipeline": {
       "archive_path": "sequence_processing_pipeline/tests/data/sequencing/knight_lab_completed_runs",
       "search_paths": [ "/tmp", "sequence_processing_pipeline/tests/data"],
-      "amplicon_search_paths": [ "/tmp", "sequence_processing_pipeline/tests/data"]
+      "amplicon_search_paths": [ "/tmp", "sequence_processing_pipeline/tests/data"],
+      "lock_file_path": "/tmp/spp_locks"
     },
     "bcl2fastq": {
       "nodes": 1,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='sequence-processing-pipeline',
       packages=['sequence_processing_pipeline'],
       setup_requires=['numpy', 'cython'],
       install_requires=[
-        'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage',
+        'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage', 'filelock',
         'metapool @ https://github.com/biocore/'
         'metagenomics_pooling_notebook/archive/master.zip'],
       )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='sequence-processing-pipeline',
       packages=['sequence_processing_pipeline'],
       setup_requires=['numpy', 'cython'],
       install_requires=[
-        'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage', 'filelock',
-        'metapool @ https://github.com/biocore/'
+        'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage',
+        'filelock', 'metapool @ https://github.com/biocore/'
         'metagenomics_pooling_notebook/archive/master.zip'],
       )


### PR DESCRIPTION
Unpredictable results can occur when two pipelines are created using the same run-identifier/run-directory and then executed. Implemented a file-based locking mechanism in mg-scripts that prevents two or more pipelines from being created using the same run-directory across multiple processes.