### PR TITLE
Fixes bug w/non 'install -e .' installs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(name='sequence-processing-pipeline',
       packages=['sequence_processing_pipeline'],
       setup_requires=['numpy', 'cython'],
       include_package_data=True,
+      package_data={'': ['templates/*']},
+
+
       install_requires=[
         'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage',
         'pgzip', 'jinja2',


### PR DESCRIPTION
templates directory was not getting installed along with python files on regular pip installs.