### PR TITLE
Added support for restarting jobs

### DIFF
--- a/sequence_processing_pipeline/ConvertJob.py
+++ b/sequence_processing_pipeline/ConvertJob.py
@@ -174,3 +174,39 @@ class ConvertJob(Job):
                 msgs.append(line)
 
         return msgs
+
+    @staticmethod
+    def parse_job_script(job_script_path):
+        # Returns run-directory and sample-sheet path from a job-script.
+
+        if not exists(job_script_path):
+            raise ValueError(f"'{job_script_path}' is not a valid path")
+
+        with open(job_script_path, 'r') as f:
+            lines = f.readlines()
+            lines = [x.strip() for x in lines]
+
+        # As this code creates this file, we can expect it to be of a certain
+        # format.
+        if lines[0] != '#!/bin/bash':
+            raise ValueError(f"'{job_script_path}' is not a valid path")
+
+        result = {}
+
+        m = re.match('^cd (.*)$', lines[12])
+
+        if m:
+            result['run_directory'] = m.group(1)
+        else:
+            raise ValueError("could not detect run_directory in "
+                             f"'{job_script_path}'")
+
+        m = re.match('^bcl-convert --sample-sheet "(.*?)" ', lines[14])
+
+        if m:
+            result['sample_sheet_path'] = m.group(1)
+        else:
+            raise ValueError("could not detect sample-sheet path in "
+                             f"'{job_script_path}'")
+
+        return result

--- a/sequence_processing_pipeline/tests/data/sample-convertjob.sh
+++ b/sequence_processing_pipeline/tests/data/sample-convertjob.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name 3f6b1fe3-1f5d-4fec-af47-31a2e35fef91_ConvertJob
+#SBATCH -p qiita
+#SBATCH -N 1
+#SBATCH -n 16
+#SBATCH --time 180
+#SBATCH --mail-type=ALL
+#SBATCH --mail-user qiita.help@gmail.com
+#SBATCH --mem-per-cpu 12gb
+set -x
+date
+hostname
+cd /sequencing/igm_runs/210820_A00953_0380_BHJ53TDSX2
+module load bclconvert_3.7.5
+bcl-convert --sample-sheet "/qmounts/qiita_data/working_dir/3f6b1fe3-1f5d-4fec-af47-31a2e35fef91/2024-02-08_U19_Wisconsin_15445_reruns_NovaSeq_nonNA.csv" --output-directory /qmounts/qiita_data/working_dir/3f6b1fe3-1f5d-4fec-af47-31a2e35fef91/ConvertJob --bcl-input-directory . --bcl-num-decompression-threads 16 --bcl-num-conversion-threads 16 --bcl-num-compression-threads 16 --bcl-num-parallel-tiles 16 --bcl-sampleproject-subdirectories true --force

--- a/sequence_processing_pipeline/tests/test_ConvertJob.py
+++ b/sequence_processing_pipeline/tests/test_ConvertJob.py
@@ -980,6 +980,21 @@ class TestConvertJob(unittest.TestCase):
         obs = job.audit(self.sample_ids + ['not-a-sample', 'BLANK1'])
         self.assertListEqual(obs, ['BLANK1', 'not-a-sample'])
 
+    def test_parse_sample_sheet(self):
+        js_path = self.base_path('sample-convertjob.sh')
+        obs = ConvertJob.parse_job_script(js_path)
+
+        exp = {
+            'run_directory': ('/sequencing/igm_runs/210820_A00953_0380_'
+                              'BHJ53TDSX2'),
+            'sample_sheet_path': ('/qmounts/qiita_data/working_dir/'
+                                  '3f6b1fe3-1f5d-4fec-af47-31a2e35fef91/'
+                                  '2024-02-08_U19_Wisconsin_15445_reruns'
+                                  '_NovaSeq_nonNA.csv')
+        }
+
+        self.assertDictEqual(obs, exp)
+
 
 SCRIPT_EXP = ''.join([
     '#!/bin/bash\n',


### PR DESCRIPTION
Added parsing for convert-job job-scripts. From these we are able to reliably retrieve the run-directory and sample-sheet path of an existing but failed job. This will allow us to retrieve the the lane value from the sample-sheet (since it was written to the sheet previously by SPP), giving us the three user-supplied values we'll need to restart a failed SPP job.