### PR TITLE
Update GenPrepFileJob()

### DIFF
--- a/sequence_processing_pipeline/GenPrepFileJob.py
+++ b/sequence_processing_pipeline/GenPrepFileJob.py
@@ -12,7 +12,7 @@ from metapool import (demux_sample_sheet, parse_prep,
 
 class GenPrepFileJob(Job):
     def __init__(self, run_dir, convert_job_path, qc_job_path, output_path,
-                 input_file_path, seqpro_path, projects, modules_to_load,
+                 input_file_path, seqpro_path, modules_to_load,
                  qiita_job_id, is_amplicon=False):
 
         super().__init__(run_dir,
@@ -38,6 +38,10 @@ class GenPrepFileJob(Job):
         # run_directory
         copytree(join(convert_job_path, 'Reports'),
                  join(self.output_path, self.run_id, 'Reports'))
+
+        # extracting from either convert_job_path or qc_job_path should
+        # produce equal results.
+        projects = self.extract_project_names_from_fastq_dir(qc_job_path)
 
         for project in projects:
             src_path = partial(join, qc_job_path, project)

--- a/sequence_processing_pipeline/tests/test_GenPrepFileJob.py
+++ b/sequence_processing_pipeline/tests/test_GenPrepFileJob.py
@@ -42,7 +42,6 @@ class TestGenPrepFileJob(unittest.TestCase):
                              join(self.working_directory_root, 'OutputPath'),
                              sample_sheet_path,
                              'seqpro',
-                             self.project_list,
                              [],
                              'abcdabcdabcdabcdabcdabcdabcdabcd')
         results = job._system_call(f'find {self.run_dir}')
@@ -82,7 +81,6 @@ class TestGenPrepFileJob(unittest.TestCase):
                              join(self.working_directory_root, 'OutputPath'),
                              sample_sheet_path,
                              'seqpro',
-                             self.project_list,
                              [],
                              'abcdabcdabcdabcdabcdabcdabcdabcd')
 
@@ -148,7 +146,6 @@ class TestReplication(unittest.TestCase):
                              join(self.working_directory_root, 'OutputPath'),
                              sample_sheet_path,
                              'seqpro',
-                             self.project_list,
                              [],
                              'abcdabcdabcdabcdabcdabcdabcdabcd')
 
@@ -197,7 +194,6 @@ class TestReplication(unittest.TestCase):
                                   'OutputPath'),
                              sample_sheet_path,
                              'seqpro',
-                             self.project_list,
                              [],
                              'abcdabcdabcdabcdabcdabcdabcdabcd',
                              is_amplicon=True)

--- a/sequence_processing_pipeline/tests/test_Job.py
+++ b/sequence_processing_pipeline/tests/test_Job.py
@@ -1,7 +1,8 @@
 import unittest
 from sequence_processing_pipeline.Job import Job
 from sequence_processing_pipeline.PipelineError import PipelineError
-from os.path import abspath, join
+from os.path import abspath, join, dirname
+from os import makedirs
 from functools import partial
 from shutil import rmtree
 import re
@@ -81,6 +82,46 @@ class TestJob(unittest.TestCase):
         self.assertEqual(results[0], '1;3;5;7')
         self.assertEqual(results[1], '2;4;6')
         self.assertEqual(len(results), 2)
+
+    def test_extract_project_names_from_fastq_dir(self):
+        package_root = abspath('./sequence_processing_pipeline')
+        base_path = partial(join, package_root, 'tests', 'data')
+
+        dummy_fastqs = [
+            "ConvertJob/NPH_15288/359180337_S27_L007_R1_001.fastq.gz",
+            "ConvertJob/NPH_15288/BLANK2_NPH_2_E_S13_L007_R1_001.fastq.gz",
+            "ConvertJob/Undetermined_S0_L007_R2_001.fastq.gz",
+            ("NuQCJob/only-adapter-filtered/NPH_15288/"
+             "359180398_S9_L007_R1_001.fastq.gz"),
+            ("NuQCJob/only-adapter-filtered/NPH_15288/"
+             "BLANK2_NPH_9_E_S69_L007_R2_001.fastq.gz"),
+            ("NuQCJob/NPH_15288/filtered_sequences/"
+             "359180396_S7_L007_R2_001.trimmed.fastq.gz")]
+
+        self.remove_these.append(base_path('7b9d7d9c-2cd4-4d54-94ac-'
+                                           '40e07a713585'))
+
+        for fastq in dummy_fastqs:
+            full_path = base_path('7b9d7d9c-2cd4-4d54-94ac-40e07a713585',
+                                  fastq)
+            makedirs(dirname(full_path), exist_ok=True)
+            with open(full_path, 'w') as f:
+                f.write("This is a dummy file.")
+
+        # fake a basic Job() object with enough metadata to test
+        # extract_project_names_from_fastq_dir().
+        job = Job(base_path('211021_A00000_0000_SAMPLE'),
+                  base_path('7b9d7d9c-2cd4-4d54-94ac-40e07a713585'),
+                  '200nnn_xnnnnn_nnnn_xxxxxxxxxx', ['ls'], 2, None)
+
+        # results from ConvertJob and NuQCJob should be equal.
+        tmp = base_path('7b9d7d9c-2cd4-4d54-94ac-40e07a713585', 'ConvertJob')
+        obs = job.extract_project_names_from_fastq_dir(tmp)
+        self.assertEqual(obs, ['NPH_15288'])
+
+        tmp = base_path('7b9d7d9c-2cd4-4d54-94ac-40e07a713585', 'NuQCJob')
+        obs = job.extract_project_names_from_fastq_dir(tmp)
+        self.assertEqual(obs, ['NPH_15288'])
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(name='sequence-processing-pipeline',
       install_requires=[
         'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage',
         'pgzip', 'jinja2',
-        'metapool @ https://github.com/charles-cowart/metagenomics_pooling_'
-        'notebook/archive/refs/heads/repl_fix2.zip',
+        'metapool @ https://github.com/biocore/'
+        'metagenomics_pooling_notebook/archive/master.zip'
         ],
       entry_points={
           'console_scripts': ['demux=sequence_processing_pipeline.scripts.cli'

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(name='sequence-processing-pipeline',
       install_requires=[
         'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage',
         'pgzip', 'jinja2',
-        'metapool @ https://github.com/charles-cowart/metagenomics_pooling_notebook/archive/repl_fix2',
+        'metapool @ https://github.com/charles-cowart/metagenomics_pooling_'
+        'notebook/archive/refs/heads/repl_fix2.zip',
         ],
       entry_points={
           'console_scripts': ['demux=sequence_processing_pipeline.scripts.cli'

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(name='sequence-processing-pipeline',
       install_requires=[
         'click', 'requests', 'pandas', 'flake8', 'nose', 'coverage',
         'pgzip', 'jinja2',
-        'metapool @ https://github.com/biocore/'
-        'metagenomics_pooling_notebook/archive/master.zip'],
+        'metapool @ https://github.com/charles-cowart/metagenomics_pooling_notebook/archive/repl_fix2',
+        ],
       entry_points={
           'console_scripts': ['demux=sequence_processing_pipeline.scripts.cli'
                               ':demux',], })


### PR DESCRIPTION
Change how GenPrepFileJob() obtains its list of projects to iterate over. Previously this was done by examining the states of other Job() objects. To recover state after a failed job, GenPrepFileJob() will now extract project information from fastq file paths.