### PR TITLE
added get_sample_names() method that's replicate compliant

### DIFF
--- a/sequence_processing_pipeline/tests/test_NuQCJob.py
+++ b/sequence_processing_pipeline/tests/test_NuQCJob.py
@@ -1282,7 +1282,6 @@ class TestNuQCJob(unittest.TestCase):
         self._helper(job.json_regex, good_names, bad_names)
 
     def test_generate_mmi_filter_cmds(self):
-        # CHARLIE
         double_db_paths = ["db_path/mmi_1.db", "db_path/mmi_2.db"]
         job = NuQCJob(self.fastq_root_path, self.output_path,
                       self.good_sample_sheet_path, double_db_paths,

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -36,6 +36,7 @@ class TestPipeline(unittest.TestCase):
         self.good_run_dir = self.path(self.good_run_id)
         self.runinfo_file = self.path(self.good_run_id, 'RunInfo.xml')
         self.rtacomplete_file = self.path(self.good_run_id, 'RTAComplete.txt')
+        self.good_sheet_w_replicates = self.path('good_sheet_w_replicates.csv')
 
         # most of the tests here were written with the assumption that these
         # files already exist.
@@ -151,6 +152,20 @@ class TestPipeline(unittest.TestCase):
         for param, exp in zip(params, exps):
             obs = set(pipeline._get_sample_names_from_sample_sheet(param))
             self.assertEqual(obs, exp)
+
+    def test_get_orig_names_from_sheet_with_replicates(self):
+        pipeline = Pipeline(self.good_config_file, self.good_run_id,
+                            self.good_sheet_w_replicates, None,
+                            self.output_file_path, self.qiita_id,
+                            Pipeline.METAGENOMIC_PTYPE)
+
+        obs = pipeline.get_orig_names_from_sheet('Feist_11661')
+        exp = {'BLANK.43.12G', 'BLANK.43.12H', 'JBI.KHP.HGL.021',
+               'JBI.KHP.HGL.022', 'JBI.KHP.HGL.023', 'JBI.KHP.HGL.024',
+               'RMA.KHP.rpoS.Mage.Q97D', 'RMA.KHP.rpoS.Mage.Q97E',
+               'RMA.KHP.rpoS.Mage.Q97L', 'RMA.KHP.rpoS.Mage.Q97N'}
+
+        self.assertEqual(set(obs), exp)
 
     def test_required_file_checks(self):
         # begin this test by deleting the RunInfo.txt file and verifying that


### PR DESCRIPTION
Added a method to Pipeline class to return a set of sample-names w/out the well-ids that would be prepended to sample-names if the sheet contains replicates.