### PR TITLE
Updated get_project_info()

### DIFF
--- a/sequence_processing_pipeline/Pipeline.py
+++ b/sequence_processing_pipeline/Pipeline.py
@@ -723,10 +723,14 @@ class Pipeline:
             for res in bioinformatics.to_dict('records'):
                 p_name, q_id = self._parse_project_name(res['Sample_Project'],
                                                         short_names)
+
+                # parsed SampleSheet() objects should now contain only
+                # boolean values in contains_replicates column.
+
                 contains_replicates = False
 
                 if 'contains_replicates' in res:
-                    if res['contains_replicates'] == 'True':
+                    if res['contains_replicates'] is True:
                         contains_replicates = True
 
                 results.append({'project_name': p_name,

--- a/sequence_processing_pipeline/tests/test_Pipeline.py
+++ b/sequence_processing_pipeline/tests/test_Pipeline.py
@@ -1558,6 +1558,17 @@ class TestPipeline(unittest.TestCase):
 
         self.assertEqual(sorted(obs_project_names), sorted(exp_project_names))
 
+        pipeline = Pipeline(self.good_config_file, self.good_run_id,
+                            self.good_sheet_w_replicates, None,
+                            self.output_file_path, self.qiita_id,
+                            Pipeline.METAGENOMIC_PTYPE)
+
+        obs_proj_info = pipeline.get_project_info()
+
+        # assert value is boolean type True, even though the method no longer
+        # silently converts string values to bool.
+        self.assertTrue(obs_proj_info[0]['contains_replicates'])
+
     def test_configuration_profiles(self):
         pipeline = Pipeline(self.good_config_file, self.good_run_id,
                             self.good_sample_sheet_path, None,


### PR DESCRIPTION
Parsed SampleSheet() objects will now only contain boolean values in the optional 'contains_replicates' column. The silent conversion from 'True' to True was removed.