### PR TITLE
WIP: All seqpro-related code clipped from metapool.

### DIFF
--- a/MOVE_TO_MGSCRIPTS/new_prep.py
+++ b/MOVE_TO_MGSCRIPTS/new_prep.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python
+
+import click
+import os
+import re
+from os.path import abspath
+from metapool.mp_strings import get_short_name_and_id
+import re
+import os
+import gzip
+import warnings
+import pandas as pd
+from glob import glob
+from datetime import datetime
+from metapool.mp_strings import get_short_name_and_id
+from metapool.plate import PlateReplication
+from collections import Counter
+from string import ascii_letters, digits
+from os import sep
+from os.path import join, split, abspath
+from collections import defaultdict
+
+from metapool import (load_sample_sheet,
+                      sample_sheet_to_dataframe, run_counts,
+                      get_qiita_id_from_project_name)
+
+def parse_illumina_run_id(run_id):
+    """Parse a run identifier
+
+    Parameters
+    ----------
+    run_id: str
+        The name of a run
+
+    Returns
+    -------
+    str:
+        When the run happened (YYYY-MM-DD)
+    str:
+        Instrument code
+    """
+
+    # Format should be YYMMDD_machinename_XXXX_FC
+    # this regex has two groups, the first one is the date, and the second one
+    # is the machine name + suffix. This URL shows some examples
+    # tinyurl.com/rmy67kw
+    matches6 = re.search(r'^(\d{6})_(\w*)', run_id)
+
+    # iSeq uses YYYYMMDD and has a trailing -XXXX value, for example
+    # 20220303_FS10001773_6_BRB11606-1914
+    # So the regex is updated to allow 8 numbers for the date, and to handle
+    # the trailing -XXXX piece
+    matches8 = re.search(r'^(\d{8})_([\w-]*)', run_id)
+
+    if matches6 is None and matches8 is None:
+        raise ValueError('Unrecognized run identifier format "%s". The '
+                         'expected format is either '
+                         'YYMMDD_machinename_XXXX_FC or '
+                         'YYYYMMDD_machinename_XXXX-XXXX' %
+                         run_id)
+
+    if matches6 is None:
+        matches = matches8
+        fmt = "%Y%m%d"
+    else:
+        matches = matches6
+        fmt = "%y%m%d"
+
+    if len(matches.groups()) != 2:
+        raise ValueError('Unrecognized run identifier format "%s". The '
+                         'expected format is either '
+                         'YYMMDD_machinename_XXXX_FC or '
+                         'YYYYMMDD_machinename_XXXX-XXXX' %
+                         run_id)
+
+    # convert illumina's format to qiita's format
+    run_date = datetime.strptime(matches[1], fmt).strftime('%Y-%m-%d')
+
+    return run_date, matches[2]
+
+
+# put together by Gail, based on the instruments we know of
+INSTRUMENT_LOOKUP = pd.DataFrame({
+    'FS10001773': {'machine prefix': 'FS', 'Vocab': 'Illumina iSeq',
+                   'Machine type': 'iSeq', 'run_center': 'KLM'},
+    'A00953': {'machine prefix': 'A', 'Vocab': 'Illumina NovaSeq 6000',
+               'Machine type': 'NovaSeq', 'run_center': 'IGM'},
+    'A00169': {'machine prefix': 'A', 'Vocab': 'Illumina NovaSeq 6000',
+               'Machine type': 'NovaSeq', 'run_center': 'LJI'},
+    'M05314': {'machine prefix': 'M', 'Vocab': 'Illumina MiSeq',
+               'Machine type': 'MiSeq', 'run_center': 'KLM'},
+    'K00180': {'machine prefix': 'K', 'Vocab': 'Illumina HiSeq 4000',
+               'Machine type': 'HiSeq', 'run_center': 'IGM'},
+    'D00611': {'machine prefix': 'D', 'Vocab': 'Illumina HiSeq 2500',
+               'Machine type': 'HiSeq/RR', 'run_center': 'IGM'},
+    'LH00444': {'machine prefix': 'LH', 'Vocab': 'Illumina NovaSeq X',
+                'Machine type': 'NovaSeq', 'run_center': 'IGM'},
+    'MN01225': {'machine prefix': 'MN', 'Vocab': 'Illumina MiniSeq',
+                'Machine type': 'MiniSeq', 'run_center': 'CMI'}}).T
+
+
+def get_machine_code(instrument_model):
+    """Get the machine code for an instrument's code
+
+    Parameters
+    ----------
+    instrument_model: str
+        An instrument's model of the form A999999 or AA999999
+
+    Returns
+    -------
+    """
+    # the machine code represents the first 1 to 2 letters of the
+    # instrument model
+    machine_code = re.compile(r'^([a-zA-Z]{1,2})')
+    matches = re.search(machine_code, instrument_model)
+    if matches is None:
+        raise ValueError('Cannot find a machine code. This instrument '
+                         'model is malformed %s. The machine code is a '
+                         'one or two character prefix.' % instrument_model)
+    return matches[0]
+
+
+
+
+
+def get_model_and_center(instrument_code):
+    """Determine instrument model and center based on a lookup
+
+    Parameters
+    ----------
+    instrument_code: str
+        Instrument code from a run identifier.
+
+    Returns
+    -------
+    str
+        Instrument model.
+    str
+        Run center based on the machine's id.
+    """
+    run_center = "UCSDMI"
+    instrument_model = instrument_code.split('_')[0]
+
+    if instrument_model in INSTRUMENT_LOOKUP.index:
+        run_center = INSTRUMENT_LOOKUP.loc[instrument_model, 'run_center']
+        instrument_model = INSTRUMENT_LOOKUP.loc[instrument_model, 'Vocab']
+    else:
+        instrument_prefix = get_machine_code(instrument_model)
+
+        if instrument_prefix not in INSTRUMENT_LOOKUP['machine prefix']:
+            ValueError('Unrecognized machine prefix %s' % instrument_prefix)
+
+        instrument_model = INSTRUMENT_LOOKUP[
+            INSTRUMENT_LOOKUP['machine prefix'] == instrument_prefix
+            ]['Vocab'].unique()[0]
+
+    return instrument_model, run_center
+
+
+
+def _find_filtered_files(fp):
+    # assume that only fastq.gz files are desired and it's okay to ignore
+    # other odd files that we find.
+
+    # assume that all desired fastq.gz files will be stored in a directory
+    # named 'filtered_sequences'. This will automatically ignore files in
+    # 'only-adapter-filtered', 'zerofiles' and possibly other directories
+    # in the future as well.
+
+    # we expect the filepaths to be of the form:
+    # <project_name_w_qiita_id>/filtered_sequences/<fastq_file>
+    # However, we intentionally search across all directories to locate
+    # any fastq files w/in a filtered_sequences subdirectory, even if
+    # they don't match our expectation so that no potentially desirable
+    # file is silently filtered out.
+    files = glob(f"{fp}/**/filtered_sequences/*.fastq.gz", recursive=True)
+
+    by_project = defaultdict(list)
+
+    for fastq_fp in files:
+        # generate the full path to each file for reference.
+        full_path = abspath(fastq_fp)
+
+        # process the relative path of each file to ensure each is of the
+        # the expected form. Report anything out of the ordinary so that no
+        # files are silently missed.
+
+        # remove fp from the beginning of the file's path. The remaining path
+        # should be of the form:
+        # <project_name_w_qiita_id>/filtered_sequences/<fastq_file>
+        tmp = fastq_fp.replace(fp, '')
+        # remove any leading and/or trailing '/' characters from the
+        # remaining path.
+        # use os.sep instead of '/' to be more platform independent.
+        tmp = tmp.strip(sep)
+        tmp = tmp.split(sep)
+
+        if len(tmp) != 3 or tmp[1] != 'filtered_sequences':
+            raise ValueError(f"{fastq_fp} appears to be stored in an "
+                             "unexpected location")
+
+        # where tmp[0] is the project_name, keep a list of all associated with
+        # that project.
+        by_project[tmp[0]].append(full_path)
+
+    return by_project
+
+
+
+
+def _map_files_to_sample_ids(sample_ids, sample_files):
+    # create a mapping of sample_ids to fastq filepaths.
+    # organize processing by file to ensure each file is mapped and errors are
+    # reported.
+    results = defaultdict(list)
+
+    for sample_file in sample_files:
+        # make no assumptions about the naming format of fastq files, other
+        # than their names will begin with a valid sample_id. This is to
+        # support non-Illumina generated fastq files.
+        _, file_name = split(sample_file)
+
+        # for each sample_file, find the subset of sample_ids that match the
+        # beginning of the file's name and assume that the longest matching
+        # sample_id is the best and proper match. Ex: myfile_sre.fastq.gz
+        # should match both the sample_ids [myfile_sre, myfile] but we want to
+        # ensure myfile_sre is the correct match, and myfile_sre.fastq.gz is
+        # not associated with myfile and myfile.fastq.gz is not associated with
+        # myfile_sre.fastq.gz.
+        matches = [s_id for s_id in sample_ids if file_name.startswith(s_id)]
+
+        # sort the matches so the longest matching sample_id will be first.
+        matches = sorted(matches, key=len, reverse=True)
+
+        if not matches:
+            # if no sample_ids could be matched to this file, then something
+            # is wrong.
+            raise ValueError(f"{sample_file} could not be matched to any "
+                             "sample-id")
+
+        # map sample_ids to a list of matching sample_files. We should expect
+        # two matches for R1 and R2 files.
+        results[matches[0]].append(sample_file)
+
+    unmatched_sample_ids = set(sample_ids) - set(list(results.keys()))
+
+    # after all possible sample_files have been matched to sample_ids, ensure
+    # that the number of matching files for each sample_id is 2 and only 2,
+    # assuming that one is an R1 file and the other is an R2 file.
+    msgs = []
+    for sample_id in results:
+        count = len(results[sample_id])
+        if count != 2:
+            msgs.append(f"{sample_id} matched an unexpected number of samples "
+                        f"({results[sample_id]})")
+    if msgs:
+        raise ValueError("\n".join(msgs))
+
+    return results, unmatched_sample_ids
+
+
+def _get_run_prefix(file_name):
+    # aka forward, reverse, and indexed reads
+    orientations = ['R1', 'R2', 'I1', 'I2']
+
+    results = []
+
+    # assume orientation is always present in the file's name.
+    # assume that it is of one of the four forms above.
+    # assume that it is always the right-most occurance of the four
+    # orientations above.
+    # assume that orientation is encapsulated with either '_' or '.'
+    # e.g.: '_R1_', '.I2.'.
+    # assume users can and will include any or all of the four
+    # orientation as part of their filenames as well. e.g.:
+    # ABC_7_04_1776_R1_SRE_S3_L007_R2_001.trimmed.fastq.gz
+    for o in orientations:
+        variations = [f"_{o}_", f".{o}."]
+        for v in variations:
+            # rfind searches from the end of the string, rather than
+            # its beginning. It returns the position in the string
+            # where the substring begins.
+            results.append((file_name.rfind(v), o))
+
+    # the orientation will be the substring found with the maximum
+    # found value for pos. That is, it will be the substring that
+    # begins at the rightest most position in the file name.
+    results.sort(reverse=True)
+
+    pos, orientation = results[0]
+
+    # if no orientations were found, then return None.
+    return None if pos == -1 else file_name[0:pos]
+
+
+
+
+def process_sample(sample, prep_columns, run_center, run_date, run_prefix,
+                   project_name, instrument_model, run_id, lane):
+    # initialize result
+    result = {c: '' for c in prep_columns}
+
+    # hard-coded columns
+    result["platform"] = "Illumina"
+    result["sequencing_meth"] = "sequencing by synthesis"
+    result["center_name"] = "UCSD"
+
+    # manually generated columns
+    result["run_center"] = run_center
+    result["run_date"] = run_date
+    result["run_prefix"] = run_prefix
+    result["center_project_name"] = project_name
+    result["instrument_model"] = instrument_model
+    result["runid"] = run_id
+
+    # lane is extracted from sample-sheet but unlike the others is passed
+    # to this function explicitly.
+    result["lane"] = lane
+
+    # handle multiple types of sample-sheets, where columns such
+    # as 'syndna_pool_number' may or may not be present.
+    additional_columns = ['syndna_pool_number', 'mass_syndna_input_ng',
+                          'extracted_gdna_concentration_ng_ul',
+                          'vol_extracted_elution_ul',
+                          'total_rna_concentration_ng_ul',
+                          "sample_name", "experiment_design_description",
+                          "library_construction_protocol", "sample_plate",
+                          "i7_index_id", "index", "i5_index_id", "index2",
+                          "sample_project", 'well_id_384', 'sample_well'
+                          ]
+
+    for attribute in additional_columns:
+        if attribute in sample:
+            result[attribute] = sample[attribute]
+
+    # sanity-checks
+    if 'well_id_384' in sample and 'sample_well' in sample:
+        # sample_well will be 'Sample_Well' to the user.
+        raise ValueError("'well_id_384' and 'Sample_Well' are both defined"
+                         "in sample.")
+
+    if 'well_id_384' not in sample and 'sample_well' not in sample:
+        raise ValueError("'well_id_384' and 'Sample_Well' are both undefined"
+                         "in sample.")
+
+    well_id = result['well_id_384'] if 'well_id_384' in sample else result[
+        'sample_well']
+
+    result["well_description"] = '%s.%s.%s' % (sample.sample_plate,
+                                               sample.sample_name,
+                                               well_id)
+
+    # return unordered result. let caller re-order columns as they see fit.
+    return result
+
+
+
+def agp_transform(frame, study_id):
+    """If the prep belongs to the American Gut Project fill in some blanks
+
+    Parameters
+    ----------
+    frame: pd.DataFrame
+        The preparation file for a single project.
+    study_id: str
+        The Qiita study identifier for this preparations.
+
+    Returns
+    -------
+    pd.DataFrame:
+        If the study_id is "10317" then:
+            - `center_name`, 'library_construction_protocol', and
+              `experiment_design_description` columns are filled in with
+              default values.
+            - `sample_name` will be zero-filled no 9 digits.
+        Otherwise no changes are made to `frame`.
+    """
+    if study_id == '10317':
+        def zero_fill(name):
+            if 'blank' not in name.lower() and name[0].isdigit():
+                return name.zfill(9)
+            return name
+
+        frame['sample_name'] = frame['sample_name'].apply(zero_fill)
+        frame['center_name'] = 'UCSDMI'
+        frame['library_construction_protocol'] = 'Knight Lab KHP'
+        frame['experiment_design_description'] = (
+            'samples of skin, saliva and feces and other samples from the AGP')
+    return frame
+
+
+def preparations_for_run(run_id, path_to_fastq_files, sheet,
+                          generated_prep_columns, carried_prep_columns):
+    """Given a run's path and sample sheet generates preparation files
+
+    Parameters
+    ----------
+    run_id: str
+        Often times the name of the directory containing raw Illumina output.
+    path_to_fastq_files: str
+        Path to a directory of filtered fastq files, organized by project.
+    sheet: dataFrame
+        dataFrame() of SampleSheet contents
+    generated_prep_columns: list
+        List of required columns for output that are not expected in
+        KLSampleSheet. It is expected that prep.py can derive these values
+        appropriately.
+    carried_prep_columns: list
+        List of required columns for output that are expected in KLSampleSheet.
+        Varies w/different versions of KLSampleSheet.
+
+    Returns
+    -------
+    dict
+        Dictionary keyed by run identifier, project name and lane. Values are
+        preparations represented as DataFrames.
+    """
+    run_date, instrument_code = parse_illumina_run_id(run_id)
+    instrument_model, run_center = get_model_and_center(instrument_code)
+
+    fastq_by_project = _find_filtered_files(path_to_fastq_files)
+
+    output = {}
+
+    # well_description is no longer a required column, since the sample-name
+    #  is now taken from column sample_name, which is distinct from sample_id.
+    # sample_id remains the version of sample_name acceptable to bcl2fastq/
+    #  bcl-convert, while sample_name is now the original string. The
+    #  well_description and description columns are no longer needed or
+    #  required, but a warning will be generated if neither are present as
+    #  they are customarily present.
+
+    # if 'well_description' is defined instead as 'description', rename it.
+    # well_description is a recommended column but is not required.
+    if 'well_description' not in set(sheet.columns):
+        warnings.warn("'well_description' is not present in sample-sheet. It "
+                      "is not a required column but it is a recommended one.")
+        if 'description' in sheet:
+            warnings.warn("Using 'description' instead of 'well_description'"
+                          " because that column isn't present", UserWarning)
+            # copy and drop the original column
+            sheet['well_description'] = sheet['description'].copy()
+            sheet.drop('description', axis=1, inplace=True)
+
+    not_present = set(carried_prep_columns) - set(sheet.columns)
+
+    if not_present:
+        raise ValueError("Required columns are missing: %s" %
+                         ', '.join(not_present))
+
+    all_columns = sorted(carried_prep_columns + generated_prep_columns)
+
+    for project, project_sheet in sheet.groupby('sample_project'):
+        project_name, qiita_id = get_short_name_and_id(project)
+
+        sample_files = fastq_by_project[project]
+        sample_ids = sheet['sample_id'].tolist()
+
+        results, unmapped_samples = _map_files_to_sample_ids(sample_ids,
+                                                             sample_files)
+
+        # make sure to put unmapped_samples into failed_samples.log
+
+        # if the Qiita ID is not found then make for an easy find/replace
+        if qiita_id == project:
+            qiita_id = 'QIITA-ID'
+
+        for lane, lane_sheet in project_sheet.groupby('lane'):
+            # this is the portion of the loop that creates the prep
+            data = []
+
+            for well_id_col, sample in lane_sheet.iterrows():
+                if isinstance(sample, pd.core.series.Series):
+                    sample_id = well_id_col
+                else:
+                    sample_id = sample.sample_id
+
+                if sample_id in unmapped_samples:
+                    # ignore these as no matching fastq files were found
+                    # for them, hence they didn't make it through conversion
+                    # and host filtering.
+                    continue
+
+                if not sample_id in results:
+                    raise ValueError("fastq.gz files were not found for "
+                                     f"sample-id '{sample_id}'")
+
+                fastq_files = results[sample_id]
+
+                t1 = _get_run_prefix(fastq_files[0])
+                t2 = _get_run_prefix(fastq_files[1])
+
+                if t1 != t2:
+                    raise ValueError(f"run_prefix values for '{sample_id}' "
+                                     f"did not match: '{t1}', '{t2}'")
+
+                run_prefix = t1
+
+                data.append(process_sample(sample, all_columns, run_center,
+                                           run_date, run_prefix, project_name,
+                                           instrument_model, run_id, lane))
+
+            if not data:
+                warnings.warn('Project %s and Lane %s have no data' %
+                              (project, lane), UserWarning)
+
+            # the American Gut Project is a special case. We'll likely continue
+            # to grow this study with more and more runs. So we fill some of
+            # the blanks if we can verify the study id corresponds to the AGP.
+            # This was a request by Daniel McDonald and Gail
+            prep = agp_transform(pd.DataFrame(columns=all_columns,
+                                              data=data), qiita_id)
+
+            _check_invalid_names(prep.sample_name)
+
+            output[(run_id, project, lane)] = prep
+
+    return output
+
+def _check_invalid_names(sample_names):
+    # taken from qiita.qiita_db.metadata.util.get_invalid_sample_names
+    valid = set(ascii_letters + digits + '.')
+
+    def _has_invalid_chars(name):
+        return bool(set(name) - valid)
+
+    invalid = sample_names[sample_names.apply(_has_invalid_chars)]
+
+    if len(invalid):
+        warnings.warn('The following sample names have invalid '
+                      'characters: %s' %
+                      ', '.join(['"%s"' % i for i in invalid.values]))
+
+
+@click.command()
+@click.argument('run_dir', type=click.Path(exists=True, dir_okay=True,
+                                           file_okay=False))
+@click.argument('sample_sheet', type=click.Path(exists=True, dir_okay=False,
+                                                file_okay=True))
+@click.argument('output_dir', type=click.Path(writable=True))
+@click.option('--verbose', help='list prep-file output paths, study_ids',
+              is_flag=True)
+def format_preparation_files(run_dir, sample_sheet, output_dir, verbose):
+    """Generate the preparation files for the projects in a run
+
+    RUN_DIR: should be the directory where the results of running bcl2fastq are
+    saved.
+
+    SAMPLE_SHEET: should be a CSV file that includes information for the
+    samples and projects in RUN_DIR.
+
+    OUTPUT_DIR: directory where the outputted preparations should be saved to.
+
+    Preparations are stratified by project and by lane. Only samples with
+    non-empty files are included. If "fastp-and-minimap2" is used, the script
+    will collect sequence count stats for each sample and add them as columns
+    in the preparation file.
+    """
+    sample_sheet = load_sample_sheet(sample_sheet)
+    df_sheet = sample_sheet_to_dataframe(sample_sheet)
+
+    stats = run_counts(run_dir, sample_sheet)
+    stats['sample_name'] = \
+        df_sheet.set_index('lane', append=True)['sample_name']
+
+    # sample_sheet_to_dataframe() automatically lowercases the column names
+    # before returning df_sheet. Hence, sample_sheet.CARRIED_PREP_COLUMNS also
+    # needs to be lowercased for the purposes of tests in
+    # preparation_for_run().
+    c_prep_columns = [x.lower() for x in sample_sheet.CARRIED_PREP_COLUMNS]
+    # returns a map of (run, project_name, lane) -> preparation frame
+    preps = preparations_for_run(run_dir,
+                                 df_sheet,
+                                 sample_sheet.GENERATED_PREP_COLUMNS,
+                                 c_prep_columns)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    for (run, project, lane), df in preps.items():
+        fp = os.path.join(output_dir, f'{run}.{project}.{lane}.tsv')
+
+        # stats are indexed by sample name and lane, lane is the first
+        # level index. When merging, make sure to select the lane subset
+        # that we care about, otherwise we'll end up with repeated rows
+        df = df.merge(stats.xs(lane, level=1), how='left', on='sample_name')
+
+        # strip qiita_id from project names in sample_project column
+        df['sample_project'] = df['sample_project'].map(
+            lambda x: re.sub(r'_\d+$', r'', x))
+
+        # center_project_name is a legacy column that should mirror
+        # the values for sample_project.
+        df['center_project_name'] = df['sample_project']
+
+        df.to_csv(fp, sep='\t', index=False)
+
+        if verbose:
+            # assume qiita_id is extractable and is an integer, given that
+            # we have already passed error-checking.
+            qiita_id = get_qiita_id_from_project_name(project)
+            print("%s\t%s" % (qiita_id, abspath(fp)))
+

--- a/MOVE_TO_MGSCRIPTS/new_prep_mf.py
+++ b/MOVE_TO_MGSCRIPTS/new_prep_mf.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python
+
+import click
+import os
+import pandas as pd
+from os.path import abspath
+import re
+import os
+import gzip
+import warnings
+import pandas as pd
+from glob import glob
+from datetime import datetime
+from metapool.mp_strings import get_short_name_and_id
+from metapool.plate import PlateReplication
+from collections import Counter
+from string import ascii_letters, digits
+from os import sep
+from os.path import join, split, abspath
+from collections import defaultdict
+
+from metapool import (
+                      get_qiita_id_from_project_name)
+
+
+
+
+PREP_MF_COLUMNS = ['sample_name', 'barcode', 'center_name',
+                   'center_project_name', 'experiment_design_description',
+                   'instrument_model', 'lane', 'library_construction_protocol',
+                   'platform', 'run_center', 'run_date', 'run_prefix', 'runid',
+                   'sample_plate', 'sequencing_meth', 'linker', 'primer',
+                   'primer_plate', 'well_id_384', 'plating',
+                   'extractionkit_lot', 'extraction_robot', 'tm1000_8_tool',
+                   'primer_date', 'mastermix_lot', 'water_lot',
+                   'processing_robot', 'tm300_8_tool', 'tm50_8_tool',
+                   'project_name', 'orig_name', 'well_description',
+                   'pcr_primers', 'target_gene', 'tm10_8_tool',
+                   'target_subfragment', 'well_id_96']
+
+
+REQUIRED_MF_COLUMNS = {'sample_name', 'barcode', 'primer', 'primer_plate',
+                       'well_id_384', 'plating', 'extractionkit_lot',
+                       'extraction_robot', 'tm1000_8_tool', 'primer_date',
+                       'mastermix_lot', 'water_lot', 'processing_robot',
+                       'tm300_8_tool', 'tm50_8_tool', 'sample_plate',
+                       'project_name', 'orig_name', 'well_description',
+                       'experiment_design_description', 'tm10_8_tool',
+                       'library_construction_protocol', 'linker', 'platform',
+                       'run_center', 'run_date', 'run_prefix', 'pcr_primers',
+                       'sequencing_meth', 'target_gene', 'target_subfragment',
+                       'center_name', 'center_project_name', 'well_id_96',
+                       'instrument_model', 'runid'}
+
+def get_run_prefix_mf(run_path, project):
+    search_path = os.path.join(run_path, project, 'amplicon',
+                               '*_SMPL1_S*R?_*.fastq.gz')
+    results = glob(search_path)
+
+    # at this stage there should only be two files forward and reverse
+    if len(results) == 2:
+        forward, reverse = sorted(results)
+        if is_nonempty_gz_file(forward) and is_nonempty_gz_file(reverse):
+            f, r = os.path.basename(forward), os.path.basename(reverse)
+            if len(f) != len(r):
+                raise ValueError("Forward and reverse sequences filenames "
+                                 "don't match f:%s r:%s" % (f, r))
+
+            # The first character that's different is the number in R1/R2. We
+            # find this position this way because sometimes filenames are
+            # written as _R1_.. or _R1.trimmed... and splitting on _R1 might
+            # catch some substrings not part of R1/R2.
+            for i in range(len(f)):
+                if f[i] != r[i]:
+                    i -= 2
+                    break
+
+            return f[:i]
+        else:
+            return None
+    elif len(results) > 2:
+        warnings.warn("%d possible matches found for determining run-prefix. "
+                      "Only two matches should be found (forward and "
+                      "reverse): %s" % (len(results),
+                                        ', '.join(sorted(results))))
+
+    return None
+
+
+
+def preparations_for_run_mapping_file(run_path, mapping_file):
+    """Given a run's path and mapping-file generates preparation files
+
+        Parameters
+        ----------
+        run_path: str
+            Path to the run folder
+        mapping_file: pandas.DataFrame
+            mapping-file to convert
+
+        Returns
+        -------
+        dict
+            Dictionary keyed by run identifier, project name and lane. Values
+            are preparations represented as DataFrames.
+        """
+
+    # lowercase all columns
+    mapping_file.columns = mapping_file.columns.str.lower()
+
+    # add a faked value for 'lane' to preserve the original logic.
+    # lane will always be '1' for amplicon runs.
+    mapping_file['lane'] = pd.Series(
+        ['1' for x in range(len(mapping_file.index))])
+
+    # add a faked column for 'Sample_ID' to preserve the original logic.
+    # count-related code will need to search run_directories based on
+    # sample-id, not sample-name.
+    mapping_file['Sample_ID'] = mapping_file.apply(
+        # importing bcl_scrub_name led to a circular import
+        lambda x: re.sub(r'[^0-9a-zA-Z\-\_]+', '_', x['sample_name']), axis=1)
+
+    output = {}
+
+    # lane is also technically a required column but since we generate it,
+    # it's not included in REQUIRED_MF_COLUMNS.
+    not_present = REQUIRED_MF_COLUMNS - set(mapping_file.columns)
+
+    if not_present:
+        raise ValueError("Required columns are missing: %s" %
+                         ', '.join(not_present))
+
+    for project, project_sheet in mapping_file.groupby('project_name'):
+        _, qiita_id = get_short_name_and_id(project)
+
+        # if the Qiita ID is not found then notify the user.
+        if qiita_id == project:
+            raise ValueError("Values in project_name must be appended with a"
+                             " Qiita Study ID.")
+
+        # note that run_prefix and run_id columns are required columns in
+        # mapping-files. We expect these columns to be blank when seqpro is
+        # run, however.
+        run_prefix = get_run_prefix_mf(run_path, project)
+
+        run_id = run_prefix.split('_SMPL1')[0]
+
+        # return an Error if run_prefix could not be determined,
+        # as it is vital for amplicon prep-info files. All projects will have
+        # the same run_prefix.
+        if run_prefix is None:
+            raise ValueError("A run-prefix could not be determined.")
+
+        for lane, lane_sheet in project_sheet.groupby('lane'):
+            lane_sheet = lane_sheet.set_index('sample_name')
+
+            # this is the portion of the loop that creates the prep
+            data = []
+
+            for sample_name, sample in lane_sheet.iterrows():
+                row = {c: '' for c in PREP_MF_COLUMNS}
+
+                row["sample_name"] = sample_name
+                row["experiment_design_description"] = \
+                    sample.experiment_design_description
+                row["library_construction_protocol"] = \
+                    sample.library_construction_protocol
+                row["platform"] = sample.platform
+                row["run_center"] = sample.run_center
+                row["run_date"] = extract_run_date_from_run_id(run_id)
+                row["run_prefix"] = run_prefix
+                row["sequencing_meth"] = sample.sequencing_meth
+                row["center_name"] = sample.center_name
+                row["center_project_name"] = sample.center_project_name
+                row["instrument_model"] = sample.instrument_model
+                row["runid"] = run_id
+                row["sample_plate"] = sample.sample_plate
+                row["lane"] = lane
+                row["barcode"] = sample.barcode
+                row["linker"] = sample.linker
+                row["primer"] = sample.primer
+                row['primer_plate'] = sample.primer_plate
+                if 'well_id_384' in sample:
+                    row["well_id_384"] = sample.well_id_384
+                elif 'sample_well' in sample:
+                    row["sample_well"] = sample.sample_well
+                row['well_id_96'] = sample.well_id_96
+                row['plating'] = sample.plating
+                row['extractionkit_lot'] = sample.extractionkit_lot
+                row['extraction_robot'] = sample.extraction_robot
+                row['tm1000_8_tool'] = sample.tm1000_8_tool
+                row['primer_date'] = sample.primer_date
+                row['mastermix_lot'] = sample.mastermix_lot
+                row['water_lot'] = sample.water_lot
+                row['processing_robot'] = sample.processing_robot
+                row['tm300_8_tool'] = sample.tm300_8_tool
+                row['tm50_8_tool'] = sample.tm50_8_tool
+                row['tm10_8_tool'] = sample.tm10_8_tool
+                row['project_name'] = sample.project_name
+                row['orig_name'] = sample.orig_name
+                row['well_description'] = sample.well_description
+                row['pcr_primers'] = sample.pcr_primers
+                row['target_gene'] = sample.target_gene
+                row['target_subfragment'] = sample.target_subfragment
+                data.append(row)
+
+            if not data:
+                warnings.warn('Project %s and Lane %s have no data' %
+                              (project, lane), UserWarning)
+
+            # the American Gut Project is a special case. We'll likely continue
+            # to grow this study with more and more runs. So we fill some of
+            # the blanks if we can verify the study id corresponds to the AGP.
+            # This was a request by Daniel McDonald and Gail
+            prep = agp_transform(pd.DataFrame(columns=PREP_MF_COLUMNS,
+                                              data=data),
+                                 qiita_id)
+
+            _check_invalid_names(prep.sample_name)
+
+            output[(run_id, project, lane)] = prep
+
+    return output
+
+@click.command()
+@click.argument('run_dir', type=click.Path(exists=True, dir_okay=True,
+                                           file_okay=False))
+@click.argument('mapping_file', type=click.Path(exists=True, dir_okay=False,
+                                                file_okay=True))
+@click.argument('output_dir', type=click.Path(writable=True))
+@click.option('--verbose', help='list prep-file output paths, study_ids',
+              is_flag=True)
+def format_preparation_files_mf(run_dir, mapping_file, output_dir, verbose):
+    """Generate the preparation files for the projects in a run
+
+    RUN_DIR: should be the directory where the results of running bcl2fastq are
+    saved.
+
+    MAPPING_FILE: should be a TSV file that includes information for the
+    samples and projects in RUN_DIR.
+
+    OUTPUT_DIR: directory where the outputted preparations should be saved to.
+
+    Preparations are stratified by project and by lane. Only samples with
+    non-empty files are included.
+    """
+    df_mf = pd.read_csv(mapping_file, delimiter='\t')
+
+    # run_counts cannot be determined for a single multiplexed file.
+
+    # returns a map of (run, project_name, lane) -> preparation frame
+    preps = preparations_for_run_mapping_file(run_dir, df_mf)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    for (run, project, lane), df in preps.items():
+        fp = os.path.join(output_dir, f'{run}.{project}.{lane}.tsv')
+
+        df.to_csv(fp,
+                  sep='\t',
+                  index=False,
+                  # finalize column order
+
+                  columns=['sample_name', 'center_name', 'center_project_name',
+                           'experiment_design_description', 'instrument_model',
+                           'lane', 'library_construction_protocol',
+                           'platform', 'run_center', 'run_date', 'run_prefix',
+                           'runid', 'sample_plate', 'sequencing_meth',
+                           'barcode', 'linker', 'primer', 'extraction_robot',
+                           'extractionkit_lot', 'mastermix_lot', 'orig_name',
+                           'pcr_primers', 'plating', 'primer_date',
+                           'primer_plate', 'processing_robot', 'project_name',
+                           'target_gene', 'target_subfragment',
+                           'tm1000_8_tool', 'tm300_8_tool', 'tm50_8_tool',
+                           'tm10_8_tool', 'water_lot', 'well_description',
+                           'well_id_384', 'well_id_96'])
+
+        if verbose:
+            # assume qiita_id is extractable and is an integer, given that
+            # we have already passed error-checking.
+            qiita_id = get_qiita_id_from_project_name(project)
+            print("%s\t%s" % (qiita_id, abspath(fp)))
+
+
+if __name__ == '__main__':
+    format_preparation_files_mf()
+

--- a/MOVE_TO_MGSCRIPTS/old_tests/test_seqpro.py
+++ b/MOVE_TO_MGSCRIPTS/old_tests/test_seqpro.py
@@ -1,0 +1,510 @@
+import os
+import re
+import unittest
+from click.testing import CliRunner
+from metapool.scripts.seqpro import format_preparation_files
+from shutil import copy, copytree, rmtree
+from os.path import join, exists
+from subprocess import Popen, PIPE
+import pandas as pd
+
+
+class SeqproTests(unittest.TestCase):
+    def setUp(self):
+        # we need to get the test data directory in the parent directory
+        # important to use abspath because we use CliRunner.isolated_filesystem
+        tests_dir = os.path.abspath(os.path.dirname(__file__))
+        tests_dir = os.path.dirname(os.path.dirname(tests_dir))
+        self.test_dir = os.path.join(tests_dir, "tests")
+        data_dir = os.path.join(self.test_dir, "data")
+        self.vf_test_dir = os.path.join(tests_dir, "tests", "VFTEST")
+
+        self.run = os.path.join(
+            data_dir, "runs", "191103_D32611_0365_G00DHB5YXX"
+        )
+        self.sheet = os.path.join(self.run, "sample-sheet.csv")
+
+        self.fastp_run = os.path.join(
+            data_dir, "runs", "200318_A00953_0082_AH5TWYDSXY"
+        )
+
+        self.fastp_sheet = os.path.join(self.fastp_run, "sample-sheet.csv")
+        self.v90_test_sheet = os.path.join(
+            self.fastp_run, "mgv90_test_sheet.csv"
+        )
+
+    def tearDown(self):
+        rmtree(self.vf_test_dir, ignore_errors=True)
+
+    def test_fastp_run(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                format_preparation_files,
+                args=[
+                    self.fastp_run,
+                    self.fastp_sheet,
+                    "./"
+                ],
+            )
+
+            self.assertEqual(result.output, "")
+            self.assertEqual(result.exit_code, 0)
+
+            exp_preps = [
+                "200318_A00953_0082_AH5TWYDSXY.Project_1111.1.tsv",
+                "200318_A00953_0082_AH5TWYDSXY.Project_1111.3.tsv",
+                "200318_A00953_0082_AH5TWYDSXY.Trojecp_666.3.tsv",
+            ]
+
+            # assert filenames are correct, and contents are correct,
+            # including columns, column order, and empty values are not
+            # present.
+            exp = {
+                "200318_A00953_0082_AH5TWYDSXY.Project_1111.1.tsv": {
+                    0: {
+                        "experiment_design_description": "Eqiiperiment",
+                        "well_description": "FooBar_666_p1.sample1.A1",
+                        "library_construction_protocol": "Knight Lab Kapa HP",
+                        "platform": "Illumina",
+                        "run_center": "IGM",
+                        "run_date": "2020-03-18",
+                        "run_prefix": "sample1_S333_L001",
+                        "sequencing_meth": "sequencing by synthesis",
+                        "center_name": "UCSD",
+                        "center_project_name": "Project",
+                        "instrument_model": "Illumina NovaSeq 6000",
+                        "runid": "200318_A00953_0082_AH5TWYDSXY",
+                        "lane": 1,
+                        "sample_project": "Project",
+                        "i5_index_id": "iTru5_01_A",
+                        "index2": "ACCGACAA",
+                        "sample_plate": "FooBar_666_p1",
+                        "well_id_384": "A1",
+                        "sample_name": "sample1",
+                        "index": "CCGACTAT",
+                        "i7_index_id": "iTru7_107_07",
+                        "raw_reads_r1r2": 10000,
+                        "quality_filtered_reads_r1r2": 16.0,
+                        "total_biological_reads_r1r2": 10800.0,
+                        "fraction_passing_quality_filter": 0.0016
+                    },
+                    1: {
+                        "experiment_design_description": "Eqiiperiment",
+                        "well_description": "FooBar_666_p1.sample2.A2",
+                        "library_construction_protocol": "Knight Lab Kapa HP",
+                        "platform": "Illumina",
+                        "run_center": "IGM",
+                        "run_date": "2020-03-18",
+                        "run_prefix": "sample2_S404_L001",
+                        "sequencing_meth": "sequencing by synthesis",
+                        "center_name": "UCSD",
+                        "center_project_name": "Project",
+                        "instrument_model": "Illumina NovaSeq 6000",
+                        "runid": "200318_A00953_0082_AH5TWYDSXY",
+                        "lane": 1,
+                        "sample_project": "Project",
+                        "i5_index_id": "iTru5_01_A",
+                        "index2": "CTTCGCAA",
+                        "sample_plate": "FooBar_666_p1",
+                        "well_id_384": "A2",
+                        "sample_name": "sample2",
+                        "index": "CCGACTAT",
+                        "i7_index_id": "iTru7_107_08",
+                        "raw_reads_r1r2": 100000,
+                        "quality_filtered_reads_r1r2": 16.0,
+                        "total_biological_reads_r1r2": 61404.0,
+                        "fraction_passing_quality_filter": 0.00016
+                    },
+                },
+                "200318_A00953_0082_AH5TWYDSXY.Project_1111.3.tsv": {
+                    0: {
+                        "experiment_design_description": "Eqiiperiment",
+                        "well_description": "FooBar_666_p1.sample1.A3",
+                        "library_construction_protocol": "Knight Lab Kapa HP",
+                        "platform": "Illumina",
+                        "run_center": "IGM",
+                        "run_date": "2020-03-18",
+                        "run_prefix": "sample1_S241_L003",
+                        "sequencing_meth": "sequencing by synthesis",
+                        "center_name": "UCSD",
+                        "center_project_name": "Project",
+                        "instrument_model": "Illumina NovaSeq 6000",
+                        "runid": "200318_A00953_0082_AH5TWYDSXY",
+                        "lane": 3,
+                        "sample_project": "Project",
+                        "i5_index_id": "iTru5_01_A",
+                        "index2": "AACACCAC",
+                        "sample_plate": "FooBar_666_p1",
+                        "well_id_384": "A3",
+                        "sample_name": "sample1",
+                        "index": "GCCTTGTT",
+                        "i7_index_id": "iTru7_107_09",
+                        "raw_reads_r1r2": 100000,
+                        "quality_filtered_reads_r1r2": 16.0,
+                        "total_biological_reads_r1r2": 335996.0,
+                        "fraction_passing_quality_filter": 0.00016
+                    },
+                    1: {
+                        "experiment_design_description": "Eqiiperiment",
+                        "well_description": "FooBar_666_p1.sample2.A4",
+                        "library_construction_protocol": "Knight Lab Kapa HP",
+                        "platform": "Illumina",
+                        "run_center": "IGM",
+                        "run_date": "2020-03-18",
+                        "run_prefix": "sample2_S316_L003",
+                        "sequencing_meth": "sequencing by synthesis",
+                        "center_name": "UCSD",
+                        "center_project_name": "Project",
+                        "instrument_model": "Illumina NovaSeq 6000",
+                        "runid": "200318_A00953_0082_AH5TWYDSXY",
+                        "lane": 3,
+                        "sample_project": "Project",
+                        "i5_index_id": "iTru5_01_A",
+                        "index2": "CGTATCTC",
+                        "sample_plate": "FooBar_666_p1",
+                        "well_id_384": "A4",
+                        "sample_name": "sample2",
+                        "index": "AACTTGCC",
+                        "i7_index_id": "iTru7_107_10",
+                        "raw_reads_r1r2": 2300000,
+                        "quality_filtered_reads_r1r2": 16.0,
+                        "total_biological_reads_r1r2": 18374.0,
+                        "fraction_passing_quality_filter":
+                            0.000006956521739130435
+                    },
+                },
+                "200318_A00953_0082_AH5TWYDSXY.Trojecp_666.3.tsv": {
+                    0: {
+                        "experiment_design_description": "SomethingWitty",
+                        "well_description": "FooBar_666_p1.sample3.A5",
+                        "library_construction_protocol": "Knight Lab Kapa HP",
+                        "platform": "Illumina",
+                        "run_center": "IGM",
+                        "run_date": "2020-03-18",
+                        "run_prefix": "sample3_S457_L003",
+                        "sequencing_meth": "sequencing by synthesis",
+                        "center_name": "UCSD",
+                        "center_project_name": "Trojecp",
+                        "instrument_model": "Illumina NovaSeq 6000",
+                        "runid": "200318_A00953_0082_AH5TWYDSXY",
+                        "lane": 3,
+                        "sample_project": "Trojecp",
+                        "i5_index_id": "iTru5_01_A",
+                        "index2": "GGTACGAA",
+                        "sample_plate": "FooBar_666_p1",
+                        "well_id_384": "A5",
+                        "sample_name": "sample3",
+                        "index": "CAATGTGG",
+                        "i7_index_id": "iTru7_107_11",
+                        "raw_reads_r1r2": 300000,
+                        "quality_filtered_reads_r1r2": 16.0,
+                        "total_biological_reads_r1r2": 4692.0,
+                        "fraction_passing_quality_filter":
+                        0.00005333333333333333
+                    },
+                    1: {
+                        "experiment_design_description": "SomethingWitty",
+                        "well_description": "FooBar_666_p1.sample4.B6",
+                        "library_construction_protocol": "Knight Lab Kapa HP",
+                        "platform": "Illumina",
+                        "run_center": "IGM",
+                        "run_date": "2020-03-18",
+                        "run_prefix": "sample4_S369_L003",
+                        "sequencing_meth": "sequencing by synthesis",
+                        "center_name": "UCSD",
+                        "center_project_name": "Trojecp",
+                        "instrument_model": "Illumina NovaSeq 6000",
+                        "runid": "200318_A00953_0082_AH5TWYDSXY",
+                        "lane": 3,
+                        "sample_project": "Trojecp",
+                        "i5_index_id": "iTru5_01_A",
+                        "index2": "CGATCGAT",
+                        "sample_plate": "FooBar_666_p1",
+                        "well_id_384": "B6",
+                        "sample_name": "sample4",
+                        "index": "AAGGCTGA",
+                        "i7_index_id": "iTru7_107_12",
+                        "raw_reads_r1r2": 400000,
+                        "quality_filtered_reads_r1r2": 16.0,
+                        "total_biological_reads_r1r2": 960.0,
+                        "fraction_passing_quality_filter": 0.00004
+                    },
+                    2: {
+                        "experiment_design_description": "SomethingWitty",
+                        "well_description": "FooBar_666_p1.sample5.B8",
+                        "library_construction_protocol": "Knight Lab Kapa HP",
+                        "platform": "Illumina",
+                        "run_center": "IGM",
+                        "run_date": "2020-03-18",
+                        "run_prefix": "sample5_S392_L003",
+                        "sequencing_meth": "sequencing by synthesis",
+                        "center_name": "UCSD",
+                        "center_project_name": "Trojecp",
+                        "instrument_model": "Illumina NovaSeq 6000",
+                        "runid": "200318_A00953_0082_AH5TWYDSXY",
+                        "lane": 3,
+                        "sample_project": "Trojecp",
+                        "i5_index_id": "iTru5_01_A",
+                        "index2": "AAGACACC",
+                        "sample_plate": "FooBar_666_p1",
+                        "well_id_384": "B8",
+                        "sample_name": "sample5",
+                        "index": "TTACCGAG",
+                        "i7_index_id": "iTru7_107_13",
+                        "raw_reads_r1r2": 567000,
+                        "quality_filtered_reads_r1r2": 16.0,
+                        "total_biological_reads_r1r2": 30846196.0,
+                        "fraction_passing_quality_filter":
+                        0.000028218694885361552
+                    },
+                },
+            }
+
+            for prep in exp_preps:
+                obs = pd.read_csv(prep, sep="\t").to_dict("index")
+                self.assertDictEqual(obs, exp[prep])
+
+    def test_verbose_flag(self):
+        self.maxDiff = None
+        sample_dir = "metapool/tests/data/runs/200318_A00953_0082_AH5TWYDSXY"
+
+        cmd = [
+            "seqpro",
+            "--verbose",
+            sample_dir,
+            join(sample_dir, "sample-sheet.csv"),
+            self.vf_test_dir,
+        ]
+
+        proc = Popen(
+            " ".join(cmd),
+            universal_newlines=True,
+            shell=True,
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+
+        stdout, stderr = proc.communicate()
+        return_code = proc.returncode
+
+        self.assertEqual("", stderr)
+        self.assertEqual(0, return_code)
+
+        tmp = []
+
+        # remove trailing whitespace before splitting each line into pairs.
+        for line in stdout.strip().split("\n"):
+            qiita_id, file_path = line.split("\t")
+            # truncate full-path output to be file-system agnostic.
+            file_path = re.sub(
+                "^.*metagenomics_pooling_notebook/",
+                "metagenomics_pooling_notebook/",
+                file_path,
+            )
+            tmp.append(f"{qiita_id}\t{file_path}")
+
+        stdout = "\n".join(tmp)
+
+        self.assertEqual(
+            (
+                "1111\tmetagenomics_pooling_notebook/metapool/tests"
+                "/VFTEST/200318_A00953_0082_AH5TWYDSXY.Project_1111"
+                ".1.tsv\n1111\tmetagenomics_pooling_notebook/metapo"
+                "ol/tests/VFTEST/200318_A00953_0082_AH5TWYDSXY.Proj"
+                "ect_1111.3.tsv\n666\tmetagenomics_pooling_notebook"
+                "/metapool/tests/VFTEST/200318_A00953_0082_AH5TWYDS"
+                "XY.Trojecp_666.3.tsv"
+            ),
+            stdout,
+        )
+
+    def test_legacy_run(self):
+        runner = CliRunner()
+
+        # confirm seqpro runs w/out error when using a legacy sample-sheet.
+        # the sheet used is sample-sheet.csv converted to v90 metagenomic
+        # spec.
+
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                format_preparation_files,
+                args=[
+                    self.fastp_run,
+                    self.v90_test_sheet,
+                    "./"
+                ],
+            )
+
+            # all we need to test is that seqpro didn't exit abnormally.
+            # this implies that it successfully processed a sample-sheet w/
+            # a mixed-case column ('Sample_Well').
+            self.assertEqual(result.output, "")
+            self.assertEqual(result.exit_code, 0)
+
+
+class SeqproBCLConvertTests(unittest.TestCase):
+    def setUp(self):
+        # we need to get the test data directory in the parent directory
+        # important to use abspath because we use CliRunner.isolated_filesystem
+        tests_dir = os.path.abspath(os.path.dirname(__file__))
+        tests_dir = os.path.dirname(os.path.dirname(tests_dir))
+        self.data_dir = os.path.join(tests_dir, "tests", "data")
+
+        self.fastp_run = os.path.join(
+            self.data_dir, "runs", "200318_A00953_0082_AH5TWYDSXY"
+        )
+        self.fastp_sheet = os.path.join(self.fastp_run, "sample-sheet.csv")
+
+        # before continuing, create a copy of 200318_A00953_0082_AH5TWYDSXY
+        # and replace Stats sub-dir with Reports.
+        self.temp_copy = self.fastp_run.replace("200318", "200418")
+        copytree(self.fastp_run, self.temp_copy)
+        rmtree(join(self.temp_copy, "Stats"))
+        os.makedirs(join(self.temp_copy, "Reports"))
+        copy(
+            join(self.data_dir, "Demultiplex_Stats.csv"),
+            join(self.temp_copy, "Reports", "Demultiplex_Stats.csv"),
+        )
+
+    def test_fastp_run(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                format_preparation_files,
+                args=[
+                    self.temp_copy,
+                    self.fastp_sheet,
+                    "./"
+                ],
+            )
+            self.assertEqual(result.output, "")
+            self.assertEqual(result.exit_code, 0)
+
+            exp_preps = [
+                "200418_A00953_0082_AH5TWYDSXY.Project_1111.1.tsv",
+                "200418_A00953_0082_AH5TWYDSXY.Project_1111.3.tsv",
+                "200418_A00953_0082_AH5TWYDSXY.Trojecp_666.3.tsv",
+            ]
+
+            self.assertEqual(sorted(os.listdir("./")), exp_preps)
+
+            for prep, exp_lines in zip(exp_preps, [4, 4, 5]):
+                with open(prep) as f:
+                    self.assertEqual(
+                        len(f.read().split("\n")),
+                        exp_lines,
+                        "Assertion error in %s" % prep,
+                    )
+
+    def tearDown(self):
+        rmtree(self.temp_copy)
+
+
+class MetricsTest(unittest.TestCase):
+    def setUp(self):
+        tests_dir = os.path.abspath(os.path.dirname(__file__))
+        tests_dir = os.path.dirname(os.path.dirname(tests_dir))
+        self.test_dir = os.path.join(tests_dir, "tests")
+        data_dir = os.path.join(self.test_dir, "data")
+        self.run = os.path.join(
+            data_dir, "runs", "240124_LH00444_0046_A223N22LT4"
+        )
+        self.sheet = os.path.join(data_dir, "good_metatv10_sheet.csv")
+        self.delete_these = []
+
+    def tearDown(self):
+        for path in self.delete_these:
+            if exists(path):
+                rmtree(path)
+
+    def test_metrics_generation(self):
+        runner = CliRunner()
+
+        out_dir = join(self.test_dir, "test_output")
+        self.delete_these.append(out_dir)
+
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                format_preparation_files, args=[self.run, self.sheet, out_dir]
+            )
+
+            # confirm seqpro exited successfully before continuing test.
+            self.assertEqual(result.exit_code, 0)
+
+        # confirm output prep-info file exists and is named as expected.
+        obs = join(out_dir, "240124_LH00444_0046_A223N22LT4.NPH_15288.7.tsv")
+        self.assertTrue(exists(obs))
+
+        # read in observed result and determine whether it matches
+        # expectations.
+        obs = pd.read_csv(obs, sep="\t", dtype=str)
+
+        exp = {
+            "center_name": {0: "UCSD", 1: "UCSD"},
+            "center_project_name": {0: "NPH", 1: "NPH"},
+            "experiment_design_description": {
+                0: "shotgun sequencing",
+                1: "shotgun sequencing",
+            },
+            "i5_index_id": {0: "iTru5_01_A", 1: "iTru5_02_A"},
+            "i7_index_id": {0: "iTru7_206_08", 1: "iTru7_206_09"},
+            "index": {0: "AAGCGCAT", 1: "CACTGACA"},
+            "index2": {0: "ACCGACAA", 1: "CTTCGCAA"},
+            "instrument_model": {
+                0: "Illumina NovaSeq X",
+                1: "Illumina NovaSeq X",
+            },
+            "lane": {0: 7, 1: 7},
+            "library_construction_protocol": {
+                0: "Knight Lab Kapa HyperPlus",
+                1: "Knight Lab Kapa HyperPlus",
+            },
+            "platform": {0: "Illumina", 1: "Illumina"},
+            "run_center": {0: "IGM", 1: "IGM"},
+            "run_date": {0: "2024-01-24", 1: "2024-01-24"},
+            "run_prefix": {0: "359250488_S19_L007", 1: "359180426_S19_L007"},
+            "runid": {
+                0: "240124_LH00444_0046_A223N22LT4",
+                1: "240124_LH00444_0046_A223N22LT4",
+            },
+            "sample_name": {0: 359250488, 1: 359180426},
+            "sample_plate": {0: "NPH_15288_P1", 1: "NPH_15288_P1"},
+            "sample_project": {0: "NPH", 1: "NPH"},
+            "sequencing_meth": {
+                0: "sequencing by synthesis",
+                1: "sequencing by synthesis",
+            },
+            # values below should reflect columns in sample-sheet input.
+            "total_rna_concentration_ng_ul": {0: 4.912, 1: 124.168},
+            # values below should reflect columns in sample-sheet input.
+            "vol_extracted_elution_ul": {0: 70, 1: 70},
+            "well_description": {
+                0: "NPH_15288_P1.359250488.A1",
+                1: "NPH_15288_P1.359180426.C1",
+            },
+            "well_id_384": {0: "A1", 1: "C1"},
+            # values below should reflect '# Reads' column found in
+            # Demultiplex_Stats.csv * 2 for both forward and reverse reads.
+            "raw_reads_r1r2": {0: 59709594, 1: 46883162},
+            # values below should reflect values extracted from fastp-
+            # generated json files.
+            "total_biological_reads_r1r2": {0: 55785054.0, 1: 41738784.0},
+            # values below should reflect # of sequences found in a fastq file
+            # by seqtk.
+            "quality_filtered_reads_r1r2": {0: 4.0, 1: 4.0},
+            "fraction_passing_quality_filter": {
+                0: 6.699090936709433e-08,
+                1: 8.531847745252336e-08,
+            }
+        }
+
+        exp = pd.DataFrame(exp, dtype=str)
+
+        self.assertTrue(obs.equals(exp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/MOVE_TO_MGSCRIPTS/old_tests/test_seqpro_mf.py
+++ b/MOVE_TO_MGSCRIPTS/old_tests/test_seqpro_mf.py
@@ -1,0 +1,131 @@
+import os
+import unittest
+
+import pandas as pd
+from click.testing import CliRunner
+from metapool.scripts.seqpro_mf import format_preparation_files_mf
+from shutil import copy, copytree, rmtree
+from os.path import join, exists
+import re
+from subprocess import Popen, PIPE
+
+
+class SeqproAmpliconTests(unittest.TestCase):
+    def setUp(self):
+        # we need to get the test data directory in the parent directory
+        # important to use abspath because we use CliRunner.isolated_filesystem
+        tests_dir = os.path.abspath(os.path.dirname(__file__))
+        tests_dir = os.path.dirname(os.path.dirname(tests_dir))
+        self.test_dir = os.path.join(tests_dir, 'tests')
+        self.data_dir = os.path.join(self.test_dir, 'data')
+        self.vf_test_dir = os.path.join(self.test_dir, 'VFTEST')
+
+        self.fastp_run = os.path.join(self.data_dir, 'runs',
+                                      '230207_M05314_0346_000000000-KVMGL')
+        self.fastp_sheet = os.path.join(self.fastp_run,
+                                        'sample_mapping_file.tsv')
+
+        # before continuing, create a copy of
+        # 230207_M05314_0346_000000000-KVMGL and replace Stats sub-dir with
+        # Reports.
+        self.temp_copy = self.fastp_run.replace('230207', '240207')
+        copytree(self.fastp_run, self.temp_copy)
+        rmtree(join(self.temp_copy, 'Stats'))
+        os.makedirs(join(self.temp_copy, 'Reports'))
+        copy(join(self.data_dir, 'Demultiplex_Stats.csv'),
+             join(self.temp_copy, 'Reports', 'Demultiplex_Stats.csv'))
+
+    def tearDown(self):
+        rmtree(self.temp_copy)
+        # this output-path isn't created for all tests. ignore error if it
+        # does not exist.
+        rmtree(self.vf_test_dir, ignore_errors=True)
+
+    def test_run(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            result = runner.invoke(format_preparation_files_mf,
+                                   args=[self.temp_copy,
+                                         join(self.temp_copy,
+                                              'sample_mapping_file.tsv'),
+                                         './'])
+
+            # assert seqpro_mf returned successfully
+            self.assertEqual(result.exit_code, 0)
+
+            obs_fp = ('./230207_M05314_0346_000000000-KVMGL.ABTX_20230208_'
+                      'ABTX_11052.1.tsv')
+
+            # assert prep-info-file output exists
+            self.assertTrue(exists(obs_fp))
+
+            obs_df = pd.read_csv(obs_fp, delimiter='\t')
+
+            # assert sample_name does not contain any '_' characters
+            names = list(obs_df['sample_name'])
+
+            # generate a list of sample-names that contain characters other
+            # than alphanumerics + '.'
+            names = [x for x in names if not bool(re.match(r"^[\w\d.]*$", x))]
+
+            # assert that all sample-names were of the proper form.
+            self.assertEqual(names, [])
+
+            # confirm correct header columns exist
+            self.assertEqual({'sample_name', 'center_name',
+                              'center_project_name',
+                              'experiment_design_description',
+                              'instrument_model', 'lane',
+                              'library_construction_protocol', 'platform',
+                              'run_center', 'run_date', 'run_prefix', 'runid',
+                              'sample_plate', 'sequencing_meth', 'barcode',
+                              'linker', 'primer', 'extraction_robot',
+                              'extractionkit_lot', 'mastermix_lot',
+                              'orig_name', 'pcr_primers', 'plating',
+                              'primer_date', 'primer_plate',
+                              'processing_robot', 'project_name',
+                              'target_gene', 'target_subfragment',
+                              'tm1000_8_tool', 'tm300_8_tool', 'tm50_8_tool',
+                              'tm10_8_tool', 'well_id_96', 'water_lot',
+                              'well_description', 'well_id_384'},
+                             set(obs_df.columns))
+
+    def test_verbose_flag(self):
+        self.maxDiff = None
+        sample_dir = (f"{self.data_dir}/runs/230207_M05314_0346_000000000"
+                      f"-KVMGL")
+
+        cmd = ['seqpro_mf', '--verbose',
+               sample_dir,
+               join(sample_dir, 'sample_mapping_file.tsv'),
+               self.vf_test_dir]
+
+        proc = Popen(' '.join(cmd), universal_newlines=True, shell=True,
+                     stdout=PIPE, stderr=PIPE)
+
+        stdout, stderr = proc.communicate()
+        return_code = proc.returncode
+
+        self.assertEqual('', stderr)
+        self.assertEqual(0, return_code)
+
+        tmp = []
+
+        # remove trailing whitespace before splitting each line into pairs.
+        for line in stdout.strip().split('\n'):
+            qiita_id, file_path = line.split('\t')
+            # truncate full-path output to be file-system agnostic.
+            file_path = re.sub('^.*metagenomics_pooling_notebook/',
+                               'metagenomics_pooling_notebook/', file_path)
+            tmp.append(f'{qiita_id}\t{file_path}')
+
+        stdout = '\n'.join(tmp)
+
+        self.assertEqual(('11052\tmetagenomics_pooling_notebook/metapool/tests'
+                          '/VFTEST/230207_M05314_0346_000000000-KVMGL.ABTX_202'
+                          '30208_ABTX_11052.1.tsv'), stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/MOVE_TO_MGSCRIPTS/test_prep.py
+++ b/MOVE_TO_MGSCRIPTS/test_prep.py
@@ -1,0 +1,1519 @@
+from os.path import join, dirname
+
+import pandas
+import pandas as pd
+
+from unittest import TestCase, main
+from metapool.sample_sheet import (MetagenomicSampleSheetv90,
+                                   MetagenomicSampleSheetv100,
+                                   sample_sheet_to_dataframe)
+from metapool.prep import (preparations_for_run, remove_qiita_id,
+                           get_run_prefix, is_nonempty_gz_file,
+                           get_machine_code, get_model_and_center,
+                           parse_illumina_run_id,
+                           _check_invalid_names, agp_transform, parse_prep,
+                           generate_qiita_prep_file, qiita_scrub_name,
+                           preparations_for_run_mapping_file, demux_pre_prep,
+                           pre_prep_needs_demuxing)
+
+
+class TestPrep(TestCase):
+    def setUp(self):
+        data_dir = join(dirname(__file__), 'data')
+        self.good_run = join(data_dir, 'runs', '191103_D32611_0365_G00DHB5YXX')
+        self.good_run_new_version = join(
+            data_dir, 'runs', '191104_D32611_0365_G00DHB5YXZ')
+        self.OKish_run_new_version = join(
+            data_dir, 'runs', '191104_D32611_0365_OK15HB5YXZ')
+
+        self.amplicon_run = join(data_dir, 'runs',
+                                 '230207_M05314_0346_000000000-KVMGL')
+
+        self.ss = join(self.good_run, 'sample-sheet.csv')
+        self.prep = join(data_dir, 'prep.tsv')
+        self.legacy_prep = join(data_dir, "legacy_prep.tsv")
+        self.mf = join(self.amplicon_run, 'sample_mapping_file.tsv')
+
+    def _check_run_191103_D32611_0365_G00DHB5YXX(self, obs):
+        "Convenience method to check the output of a whole run"
+
+        exp = {('191103_D32611_0365_G00DHB5YXX', 'Baz_12345', '1'),
+               ('191103_D32611_0365_G00DHB5YXX', 'Baz_12345', '3'),
+               ('191103_D32611_0365_G00DHB5YXX', 'FooBar_666', '3')}
+        self.assertEqual(set(obs.keys()), exp)
+
+        columns = ['sample_name', 'experiment_design_description',
+                   'library_construction_protocol', 'platform', 'run_center',
+                   'run_date', 'run_prefix', 'sequencing_meth', 'center_name',
+                   'center_project_name', 'instrument_model', 'runid',
+                   'sample_plate', 'well_id_384', 'i7_index_id', 'index',
+                   'i5_index_id', 'index2', 'lane', 'sample_project',
+                   'well_description']
+
+        data = [['sample.1', 'Eqiiperiment', 'Knight Lab Kapa HP',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample_1_S11_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'A3', 'iTru7_107_09', 'GCCTTGTT',
+                 'iTru5_01_A', 'AACACCAC', '3', 'Baz_12345',
+                 'FooBar_666_p1.sample.1.A3'],
+                ['sample.44', 'Eqiiperiment', 'Knight Lab Kapa HP',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample_44_S14_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'Baz_12345_p3', 'B99', 'iTru7_107_14', 'GTCCTAAG',
+                 'iTru5_01_A', 'CATCTGCT', '3', 'Baz_12345',
+                 'Baz_12345_p3.sample.44.B99']]
+
+        exp = pd.DataFrame(data=data, columns=columns)
+
+        # obs is a dictionary of dataframes, where the keys are tuples of
+        # strings, rather than ordinary strings. We'll use the dataframe
+        # associated w/('191103_D32611_0365_G00DHB5YXX', 'Baz_12345', '3') for
+        # our unittest.
+        obs_df = obs[('191103_D32611_0365_G00DHB5YXX', 'Baz_12345', '3')]
+
+        # make sure the columns are in the same order before comparing
+        obs_df = obs_df[exp.columns].copy()
+
+        pd.testing.assert_frame_equal(obs_df, exp)
+
+        data = [['sample.1', 'Eqiiperiment', 'Knight Lab Kapa HP',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample_1_S11_L001',
+                 'sequencing by synthesis', 'UCSD', 'Baz',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'A1', 'iTru7_107_07', 'CCGACTAT',
+                 'iTru5_01_A', 'ACCGACAA', '1', 'Baz_12345',
+                 'FooBar_666_p1.sample.1.A1'],
+                ['sample.2', 'Eqiiperiment', 'Knight Lab Kapa HP',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample_2_S10_L001',
+                 'sequencing by synthesis', 'UCSD', 'Baz',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'A2', 'iTru7_107_08', 'CCGACTAT',
+                 'iTru5_01_A', 'CTTCGCAA', '1', 'Baz_12345',
+                 'FooBar_666_p1.sample.2.A2']]
+        exp = pd.DataFrame(columns=columns, data=data)
+        obs_df = obs[('191103_D32611_0365_G00DHB5YXX', 'Baz_12345', '1')]
+
+        # make sure the columns are in the same order before comparing
+        obs_df = obs_df[exp.columns].copy()
+        pd.testing.assert_frame_equal(obs_df, exp)
+
+        data = [['sample.31', 'SomethingWitty', 'Knight Lab Kapa HP',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample_31_S13_L003',
+                 'sequencing by synthesis', 'UCSD', 'FooBar',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'A5', 'iTru7_107_11', 'CAATGTGG',
+                 'iTru5_01_A', 'GGTACGAA', '3', 'FooBar_666',
+                 'FooBar_666_p1.sample.31.A5'],
+                ['sample.32', 'SomethingWitty', 'Knight Lab Kapa HP',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample_32_S19_L003',
+                 'sequencing by synthesis', 'UCSD', 'FooBar',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'B6', 'iTru7_107_12', 'AAGGCTGA',
+                 'iTru5_01_A', 'CGATCGAT', '3', 'FooBar_666',
+                 'FooBar_666_p1.sample.32.B6'],
+                ['sample.34', 'SomethingWitty', 'Knight Lab Kapa HP',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample_34_S33_L003',
+                 'sequencing by synthesis', 'UCSD', 'FooBar',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'B8', 'iTru7_107_13', 'TTACCGAG',
+                 'iTru5_01_A', 'AAGACACC', '3', 'FooBar_666',
+                 'FooBar_666_p1.sample.34.B8']]
+        exp = pd.DataFrame(columns=columns, data=data)
+        obs_df = obs[('191103_D32611_0365_G00DHB5YXX', 'FooBar_666', '3')]
+
+        # make sure the columns are in the same order before comparing
+        obs_df = obs_df[exp.columns].copy()
+        pd.testing.assert_frame_equal(obs_df, exp)
+
+    def _check_run_230207_M05314_0346_000000000_KVMGL(self, obs):
+        # confirm correct keys are present for the output prep
+        exp_keys = {('230207_M05314_0346_000000000-KVMGL',
+                     'ABTX_20230208_ABTX_11052', '1')}
+
+        self.assertEqual(set(obs.keys()), exp_keys)
+
+        # confirm the observed prep-info output contains the expected
+        # columns.
+        obs_df = obs[('230207_M05314_0346_000000000-KVMGL',
+                      'ABTX_20230208_ABTX_11052', '1')]
+
+        exp_columns = ['sample_name', 'barcode', 'center_name', 'platform',
+                       'center_project_name', 'experiment_design_description',
+                       'instrument_model', 'lane', 'run_center', 'run_date',
+                       'library_construction_protocol', 'run_prefix', 'runid',
+                       'sample_plate', 'sequencing_meth', 'linker', 'primer',
+                       'target_gene', 'pcr_primers', 'primer_plate',
+                       'processing_robot', 'well_description',
+                       'extraction_robot', 'tm300_8_tool', 'water_lot',
+                       'extractionkit_lot', 'target_subfragment',
+                       'well_id_384', 'project_name', 'tm1000_8_tool',
+                       'orig_name', 'plating', 'primer_date', 'mastermix_lot',
+                       'tm50_8_tool', 'well_id_96', 'tm10_8_tool']
+
+        self.assertEqual(set(exp_columns), set(obs_df.columns))
+
+        exp_data = [
+            ["sample.1", "AGCCTTCGTCGC", "UCSDMI", "Illumina",
+             "SOME_CENTER_PROJECT_NAME",
+             "This is a description of the experiment design.",
+             "SOME_INSTRUMENT_MODEL", "1", "UCSDMI", "2023/02/07",
+             "Illumina EMP protocol 515fbc, 806r amplification of 16S rRNA V4",
+             "230207_M05314_0346_000000000-KVMGL_SMPL1_S1_L001",
+             "230207_M05314_0346_000000000-KVMGL",
+             "ABTX_20230208_11052_Plate_238", "Sequencing by synthesis", "GT",
+             "GTGTGYCAGCMGCCGCGGTAA", "16S rRNA",
+             "FWD:GTGYCAGCMGCCGCGGTAA; REV:GGACTACNVGGGTWTCTAAT", 1,
+             "Echo 550", "ABTX_20230208_11052_Plate_238_11.8.21.RK.FH_A1",
+             float("nan"), float("nan"), 1317793, float("nan"), "V4", "A1",
+             "ABTX_20230208_ABTX_11052", "108379Z", "sample.1", "HT", 122822,
+             1331807, float("nan"), "A1", float("nan"), ],
+            ["sample.2", "TCCATACCGGAA", "UCSDMI", "Illumina",
+             "SOME_CENTER_PROJECT_NAME",
+             "This is a description of the experiment design.",
+             "SOME_INSTRUMENT_MODEL", "1", "UCSDMI", "2023/02/07",
+             "Illumina EMP protocol 515fbc, 806r amplification of 16S rRNA V4",
+             "230207_M05314_0346_000000000-KVMGL_SMPL1_S1_L001",
+             "230207_M05314_0346_000000000-KVMGL",
+             "ABTX_20230208_11052_Plate_238", "Sequencing by synthesis", "GT",
+             "GTGTGYCAGCMGCCGCGGTAA", "16S rRNA",
+             "FWD:GTGYCAGCMGCCGCGGTAA; REV:GGACTACNVGGGTWTCTAAT", 1,
+             "Echo 550", "ABTX_20230208_11052_Plate_238_11.17.21.RK.FH_A2",
+             float("nan"), float("nan"), 1317793, float("nan"), "V4", "A2",
+             "ABTX_20230208_ABTX_11052", "108379Z", "sample.2", "HT", 122822,
+             1331807, float("nan"), "A2", float("nan"), ],
+        ]
+
+        # confirm that the observed data in the prep-info output matches
+        # what's expected.
+
+        exp_df = pd.DataFrame(columns=exp_columns, data=exp_data)
+
+        # ensure the column order for the observed dataframe is the same as
+        # what's expected. (a canonical column ordering isn't required.)
+        obs_df = obs_df[exp_df.columns].copy()
+
+        pd.testing.assert_frame_equal(obs_df, exp_df)
+
+    def test_preparations_for_run(self):
+        sheet = MetagenomicSampleSheetv100(self.ss)
+
+        # obs will be a dictionary of dataframes, with the keys being
+        # a triplet of strings, rather than a single string.
+        obs = preparations_for_run(self.good_run,
+                                   sample_sheet_to_dataframe(sheet),
+                                   sheet.GENERATED_PREP_COLUMNS,
+                                   sheet.CARRIED_PREP_COLUMNS)
+        self._check_run_191103_D32611_0365_G00DHB5YXX(obs)
+
+    def test_preparations_for_run_missing_columns(self):
+        # Check that warnings are raised whenever we overwrite the
+        # "well_description" column with the "description" column
+        sheet = MetagenomicSampleSheetv100(self.ss)
+        ss = sample_sheet_to_dataframe(sheet)
+        ss['description'] = ss['well_description'].copy()
+        ss.drop('well_description', axis=1, inplace=True)
+
+        with self.assertWarns(UserWarning) as cm:
+            obs = preparations_for_run(self.good_run, ss,
+                                       sheet.GENERATED_PREP_COLUMNS,
+                                       sheet.CARRIED_PREP_COLUMNS)
+
+            self.assertEqual(str(cm.warnings[0].message), "'well_description' "
+                                                          "is not present in s"
+                                                          "ample-sheet. It is "
+                                                          "not a required colu"
+                                                          "mn but it is a reco"
+                                                          "mmended one.")
+            self.assertEqual(str(cm.warnings[1].message), "Using 'description'"
+                                                          " instead of 'well_d"
+                                                          "escription' because"
+                                                          " that column isn't "
+                                                          "present")
+
+        self._check_run_191103_D32611_0365_G00DHB5YXX(obs)
+
+    def test_preparations_for_run_mf(self):
+        # mf has a header w/mixed case. This will test whether mapping-file
+        # headers are properly converted to all lower-case.
+        mf = pandas.read_csv(self.mf, delimiter='\t')
+
+        # obs will be a dictionary of dataframes, with the keys being
+        # a triplet of strings, rather than a single string.
+        obs = preparations_for_run_mapping_file(self.amplicon_run, mf)
+
+        self._check_run_230207_M05314_0346_000000000_KVMGL(obs)
+
+        # remove a column, simulating reading in a file with a column
+        # missing.
+        mf = mf.drop('project_name', axis=1)
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Required columns are missing: '
+                                    'project_name'):
+            preparations_for_run_mapping_file(self.amplicon_run, mf)
+
+    def test_invalid_sample_names_show_warning(self):
+        ss = MetagenomicSampleSheetv90(self.ss)
+
+        self.assertIsNotNone(ss)
+
+        ss = sample_sheet_to_dataframe(ss)
+
+        ss['well_description'] = ss['well_description'].str.replace(
+            'importantsample44', 'important-sample44')
+
+        with self.assertWarns(UserWarning) as cm:
+            _check_invalid_names(ss['well_description'])
+            self.assertEqual(str(cm.warnings[0].message), 'The following sampl'
+                                                          'e names have invali'
+                                                          'd characters: "impo'
+                                                          'rtant-sample44"'
+                             )
+
+    def test_remove_qiita_id(self):
+        obs = remove_qiita_id('project_1')
+        self.assertEqual(obs, 'project')
+
+        obs = remove_qiita_id('project_00333333')
+        self.assertEqual(obs, 'project')
+
+        obs = remove_qiita_id('project')
+        self.assertEqual(obs, 'project')
+
+        obs = remove_qiita_id('project_')
+        self.assertEqual(obs, 'project_')
+
+    def test_get_run_prefix(self):
+        # project 1
+        obs = get_run_prefix(self.good_run, 'Baz_12345', 'sample_1', '1')
+        self.assertEqual('sample_1_S11_L001', obs)
+
+        obs = get_run_prefix(self.good_run, 'Baz_12345', 'sample_1', '3')
+        self.assertEqual('sample_1_S11_L003', obs)
+
+        obs = get_run_prefix(self.good_run, "Baz_12345", "sample_2", "1")
+        self.assertEqual("sample_2_S10_L001", obs)
+
+        # project 2
+        obs = get_run_prefix(self.good_run, 'FooBar_666', 'sample_31', '3')
+        self.assertEqual('sample_31_S13_L003', obs)
+
+        obs = get_run_prefix(self.good_run, 'FooBar_666', 'sample_32', '3')
+        self.assertEqual('sample_32_S19_L003', obs)
+
+        obs = get_run_prefix(self.good_run, 'FooBar_666', 'sample_34', '3')
+        self.assertEqual('sample_34_S33_L003', obs)
+
+    def test_get_run_prefix_fastp_minimap(self):
+        obs = get_run_prefix(self.good_run_new_version, 'Baz_12345', 'sample1',
+                             '1')
+        self.assertEqual('sample1_S11_L001', obs)
+
+        obs = get_run_prefix(self.good_run_new_version, 'Baz_12345', 'sample1',
+                             '3')
+        self.assertEqual('sample1_S11_L003', obs)
+
+        obs = get_run_prefix(self.good_run_new_version, 'Baz_12345', 'sample2',
+                             '1')
+        self.assertEqual('sample2_S10_L001', obs)
+
+        obs = get_run_prefix(self.good_run_new_version, 'Baz_12345',
+                             'sample44', '3')
+        self.assertIsNone(obs)
+
+        obs = get_run_prefix(self.good_run_new_version, 'Baz_12345', 'sample2',
+                             '3')
+        self.assertIsNone(obs)
+
+        # project 2
+        obs = get_run_prefix(self.good_run_new_version, 'FooBar_666',
+                             'sample31', '3')
+        self.assertEqual('sample31_S13_L003', obs)
+
+        obs = get_run_prefix(self.good_run_new_version, 'FooBar_666',
+                             'sample32', '3')
+        self.assertEqual('sample32_S19_L003', obs)
+
+        obs = get_run_prefix(self.good_run_new_version, 'FooBar_666',
+                             'sample34', '3')
+        self.assertIsNone(obs)
+
+    def test_get_run_prefix_more_than_forward_and_reverse(self):
+        message = (r'There are 3 matches for sample "sample31" in lane 3\. '
+                   r'Only two matches are allowed \(forward and reverse\): '
+                   '(.*)metapool/tests/data/runs/191104_D32611_0365_OK15HB5YXZ'
+                   r'/FooBar_666/filtered_sequences/sample31_S13_L003_R1\.'
+                   r'filtered\.fastq\.gz, '
+                   '(.*)metapool/tests/data/runs/191104_D32611_0365_OK15HB5YXZ'
+                   r'/FooBar_666/filtered_sequences/sample31_S13_L003_R2\.'
+                   r'filtered\.fastq\.gz, '
+                   '(.*)metapool/tests/data/runs/191104_D32611_0365_OK15HB5YXZ'
+                   r'/FooBar_666/filtered_sequences/sample31_S14_L003_R1\.'
+                   r'filtered\.fastq\.gz')
+        # project 2
+        with self.assertWarnsRegex(Warning, message):
+            obs = get_run_prefix(self.OKish_run_new_version, 'FooBar_666',
+                                 'sample31', '3')
+            self.assertIsNone(obs)
+
+        obs = get_run_prefix(self.OKish_run_new_version, 'FooBar_666',
+                             'sample32', '3')
+        self.assertEqual('sample32_S19_L003', obs)
+
+        obs = get_run_prefix(self.OKish_run_new_version, 'FooBar_666',
+                             'sample34', '3')
+        self.assertIsNone(obs)
+
+    def test_is_non_empty_gz_file(self):
+        non_empty = join(self.good_run, 'Baz_12345', 'sample_2_S10_L001_R1_0'
+                                                     '01.fastq.gz')
+        self.assertTrue(is_nonempty_gz_file(non_empty))
+        non_empty = join(self.good_run, 'Baz_12345', 'sample_2_S10_L001_R2_0'
+                                                     '01.fastq.gz')
+        self.assertTrue(is_nonempty_gz_file(non_empty))
+        empty = join(self.good_run, 'Baz_12345/atropos_qc/sample_2_S10_L003_'
+                                    'R1_001.fastq.gz')
+        self.assertFalse(is_nonempty_gz_file(empty))
+        empty = join(self.good_run, 'Baz_12345/atropos_qc/sample_2_S10_L003_'
+                                    'R2_001.fastq.gz')
+        self.assertFalse(is_nonempty_gz_file(empty))
+
+    def test_parse_illumina_run_id(self):
+        date, rid = parse_illumina_run_id('161004_D00611_0365_AH2HJ5BCXY')
+        self.assertEqual(date, '2016-10-04')
+        self.assertEqual(rid, 'D00611_0365_AH2HJ5BCXY')
+
+        date, rid = parse_illumina_run_id('160909_K00180_0244_BH7VNKBBXX')
+        self.assertEqual(date, '2016-09-09')
+        self.assertEqual(rid, 'K00180_0244_BH7VNKBBXX')
+
+        date, rid = parse_illumina_run_id('20220303_FS10001773_6_BRB11606-1914')  # noqa
+        self.assertEqual(date, '2022-03-03')
+        self.assertEqual(rid, 'FS10001773_6_BRB11606-1914')
+
+    def test_parse_illumina_run_id_malformed(self):
+        bad_entries = ['0220303_FS10001773_6_BRB11606-1914',
+                       'verybad', '123456-bad', '12345678-bad']
+        for bad in bad_entries:
+            with self.assertRaises(ValueError):
+                parse_illumina_run_id(bad)
+
+    def test_machine_code(self):
+        obs = get_machine_code('K00180')
+        self.assertEqual(obs, 'K')
+
+        obs = get_machine_code('D00611')
+        self.assertEqual(obs, 'D')
+
+        obs = get_machine_code('MN01225')
+        self.assertEqual(obs, 'MN')
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Cannot find a machine code. This '
+                                    'instrument model is malformed 8675309. '
+                                    'The machine code is a one or two '
+                                    'character prefix.'):
+            get_machine_code('8675309')
+
+    def test_get_model_and_center(self):
+        obs = get_model_and_center('D32611_0365_G00DHB5YXX')
+        self.assertEqual(obs, ('Illumina HiSeq 2500', 'UCSDMI'))
+
+        obs = get_model_and_center('A86753_0365_G00DHB5YXX')
+        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'UCSDMI'))
+
+        obs = get_model_and_center('A00953_0032_AHWMGJDDXX')
+        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'IGM'))
+
+        obs = get_model_and_center('A00169_8131_AHKXYNDHXX')
+        self.assertEqual(obs, ('Illumina NovaSeq 6000', 'LJI'))
+
+        obs = get_model_and_center('M05314_0255_000000000-J46T9')
+        self.assertEqual(obs, ('Illumina MiSeq', 'KLM'))
+
+        obs = get_model_and_center('K00180_0957_AHCYKKBBXY')
+        self.assertEqual(obs, ('Illumina HiSeq 4000', 'IGM'))
+
+        obs = get_model_and_center('D00611_0712_BH37W2BCX3_RKL0040')
+        self.assertEqual(obs, ('Illumina HiSeq 2500', 'IGM'))
+
+        obs = get_model_and_center('MN01225_0002_A000H2W3FY')
+        self.assertEqual(obs, ('Illumina MiniSeq', 'CMI'))
+
+    def test_agp_transform(self):
+        columns = ['sample_name', 'experiment_design_description',
+                   'library_construction_protocol', 'platform', 'run_center',
+                   'run_date', 'run_prefix', 'sequencing_meth', 'center_name',
+                   'center_project_name', 'instrument_model', 'runid',
+                   'sample_plate', 'well_id_384', 'i7_index_id', 'index',
+                   'i5_index_id', 'index2', 'lane', 'sample_project',
+                   'well_description']
+
+        data = [['importantsample1', 'EXPERIMENT_DESC', 'LIBRARY_PROTOCOL',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample1_S11_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz_12345',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'A3', 'iTru7_107_09', 'GCCTTGTT',
+                 'iTru5_01_A', 'AACACCAC', '3', 'Baz_12345',
+                 'FooBar_666_p1.sample1.A3'],
+                ['importantsample44', 'EXPERIMENT_DESC', 'LIBRARY_PROTOCOL',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample44_S14_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz_12345',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'Baz_12345_p3', 'B99', 'iTru7_107_14', 'GTCCTAAG',
+                 'iTru5_01_A', 'CATCTGCT', '3', 'Baz_12345',
+                 'Baz_12345_p3.sample44.B99']]
+        obs = pd.DataFrame(data=data, columns=columns)
+        exp = obs.copy()
+        exp['center_name'] = 'UCSDMI'
+        exp['library_construction_protocol'] = 'Knight Lab KHP'
+        exp['experiment_design_description'] = (
+            'samples of skin, saliva and feces and other samples from the AGP')
+
+        pd.testing.assert_frame_equal(agp_transform(obs, '10317'), exp)
+
+    def test_agp_transform_zfill(self):
+        columns = ['sample_name', 'experiment_design_description',
+                   'library_construction_protocol', 'platform', 'run_center',
+                   'run_date', 'run_prefix', 'sequencing_meth', 'center_name',
+                   'center_project_name', 'instrument_model', 'runid',
+                   'sample_plate', 'well_id_384', 'i7_index_id', 'index',
+                   'i5_index_id', 'index2', 'lane', 'sample_project',
+                   'well_description']
+
+        # the first sample name should be padded with 2 zeros
+        # the second number should be padded with 1 zero
+        # the third should be ignored
+        data = [['8675309', 'EXPERIMENT_DESC', 'LIBRARY_PROTOCOL', 'Illumina',
+                 'UCSDMI', '2019-11-03', 'sample1_S11_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz_12345',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'A3', 'iTru7_107_09', 'GCCTTGTT',
+                 'iTru5_01_A', 'AACACCAC', '3', 'Baz_12345',
+                 'FooBar_666_p1.sample1.A3'],
+                ['867530.9', 'EXPERIMENT_DESC', 'LIBRARY_PROTOCOL', 'Illumina',
+                 'UCSDMI', '2019-11-03', 'sample44_S14_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz_12345',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'Baz_12345_p3', 'B99', 'iTru7_107_14', 'GTCCTAAG',
+                 'iTru5_01_A', 'CATCTGCT', '3', 'Baz_12345',
+                 'Baz_12345_p3.sample44.B99'],
+                ['notanumber', 'EXPERIMENT_DESC', 'LIBRARY_PROTOCOL',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample44_S14_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz_12345',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'Baz_12345_p3', 'B99', 'iTru7_107_14', 'GTCCTAAG',
+                 'iTru5_01_A', 'CATCTGCT', '3', 'Baz_12345',
+                 'Baz_12345_p3.sample44.B99']]
+        obs = pd.DataFrame(data=data, columns=columns)
+        exp = obs.copy()
+        exp['center_name'] = 'UCSDMI'
+        exp['library_construction_protocol'] = 'Knight Lab KHP'
+        exp['experiment_design_description'] = (
+            'samples of skin, saliva and feces and other samples from the AGP')
+        exp.loc[0, 'sample_name'] = '008675309'
+        exp.loc[1, 'sample_name'] = '0867530.9'
+
+        pd.testing.assert_frame_equal(agp_transform(obs, '10317'), exp)
+
+    def test_agp_transform_no_agp(self):
+        columns = ['sample_name', 'experiment_design_description',
+                   'library_construction_protocol', 'platform', 'run_center',
+                   'run_date', 'run_prefix', 'sequencing_meth', 'center_name',
+                   'center_project_name', 'instrument_model', 'runid',
+                   'sample_plate', 'well_id_384', 'i7_index_id', 'index',
+                   'i5_index_id', 'index2', 'lane', 'sample_project',
+                   'well_description']
+
+        data = [['importantsample1', 'EXPERIMENT_DESC', 'LIBRARY_PROTOCOL',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample1_S11_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz_12345',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'FooBar_666_p1', 'A3', 'iTru7_107_09', 'GCCTTGTT',
+                 'iTru5_01_A', 'AACACCAC', '3', 'Baz_12345',
+                 'FooBar_666_p1.sample1.A3'],
+                ['importantsample44', 'EXPERIMENT_DESC', 'LIBRARY_PROTOCOL',
+                 'Illumina', 'UCSDMI', '2019-11-03', 'sample44_S14_L003',
+                 'sequencing by synthesis', 'UCSD', 'Baz_12345',
+                 'Illumina HiSeq 2500', '191103_D32611_0365_G00DHB5YXX',
+                 'Baz_12345_p3', 'B99', 'iTru7_107_14', 'GTCCTAAG',
+                 'iTru5_01_A', 'CATCTGCT', '3', 'Baz_12345',
+                 'Baz_12345_p3.sample44.B99']]
+        obs = pd.DataFrame(data=data, columns=columns)
+        exp = obs.copy()
+
+        # there shouldn't be any changes
+        pd.testing.assert_frame_equal(agp_transform(obs, '666'), exp)
+
+    def test_parse_prep(self):
+        columns = [
+            'barcode', 'primer', 'project_name', 'well_id_384',
+            'primer_plate', 'plating', 'extractionkit_lot',
+            'extraction_robot', 'tm1000_8_tool', 'primer_date',
+            'mastermix_lot', 'water_lot', 'processing_robot',
+            'sample_plate', 'linker', 'orig_name', 'well_description',
+            'pcr_primers', 'center_name', 'run_center', 'platform',
+            'target_subfragment', 'target_gene', 'sequencing_meth',
+            'library_construction_protocol']
+
+        additional_columns = [
+            "vol_extracted_elution_ul",
+            "platemap_generation_date",
+            "project_abbreviation",
+            "TubeCode",
+            "Kathseq_RackID",
+            "number_of_cells",
+            "description",
+        ]
+
+        data = [
+            ['AGCCTTCGTCGC', 'GTGYCAGCMGCCGCGGTAA', 'THDMI_10317', 'A1', '1',
+             'SF', '166032128', 'Carmen_HOWE_KF3', '109379Z', '2021-08-17',
+             '978215', 'RNBJ0628', 'Echo550', 'THDMI_UK_Plate_2', 'GT',
+             'X00180471', 'THDMI_UK_Plate_2.X00180471.A1',
+             'FWD:GTGYCAGCMGCCGCGGTAA; REV:GGACTACNVGGGTWTCTAAT', 'UCSDMI',
+             'UCSDMI', 'Illumina', 'V4', '16S rRNA', 'Sequencing by synthesis',
+             'Illumina EMP protocol 515fbc, 806r amplification of 16S rRNA V4'
+             ],
+            ['CGTATAAATGCG', 'GTGYCAGCMGCCGCGGTAA', 'THDMI_10317', 'C1', '1',
+             'SF', '166032128', 'Carmen_HOWE_KF3', '109379Z', '2021-08-17',
+             '978215', 'RNBJ0628', 'Echo550', 'THDMI_UK_Plate_2', 'GT',
+             'X00180199', 'THDMI_UK_Plate_2.X00180199.C1',
+             'FWD:GTGYCAGCMGCCGCGGTAA; REV:GGACTACNVGGGTWTCTAAT', 'UCSDMI',
+             'UCSDMI', 'Illumina', 'V4', '16S rRNA',
+             'Sequencing by synthesis',
+             'Illumina EMP protocol 515fbc, 806r amplification of 16S rRNA V4']
+        ]
+
+        additional_data = ["70", "20230627", "ADAPT", "0363132553", "", "", ""]
+
+        index = pd.Index(["X00180471", "X00180199"], name="sample_name")
+        exp = pd.DataFrame(data=data, columns=columns, index=index)
+
+        # prep-info files do not currently have versions, unlike sample-sheets.
+        # Moreover, a prep-info file w/or w/out karathoseq columns will be
+        # accepted by Qiita and are possible w/optional karathoseq columns in
+        # MetagenomicSampleSheetv101(). Hence, we should test both versions.
+        obs = parse_prep(self.legacy_prep)
+        pd.testing.assert_frame_equal(obs, exp)
+
+        # append karathoseq metadata and recreate the expected DataFrame.
+        columns += additional_columns
+        data[0] += additional_data
+        data[1] += additional_data
+
+        exp = pd.DataFrame(data=data, columns=columns, index=index)
+        obs = parse_prep(self.prep)
+
+        pd.testing.assert_frame_equal(obs, exp)
+
+    def test_qiita_prep_file_duplicate_columns(self):
+        columns1 = [
+            "Sample",
+            "Row",
+            "Col",
+            "Blank",
+            "Project Plate",
+            # will convert to project_name
+            "Compressed Plate Name",
+            "Well",
+            "Plate Position",
+            "Primer Plate #",
+            "Sample Plate",
+            # will convert to project_name
+            "Project_Name",
+            "Plating",
+            "Extraction Kit Lot",
+            "Extraction Robot",
+            "TM1000 8 Tool",
+            "Primer Date",
+            "MasterMix Lot",
+            "Water Lot",
+            "Processing Robot",
+            "Original Name",
+            "Plate",
+            "EMP Primer Plate Well",
+            "Name",
+            "Illumina 5prime Adapter",
+            "Golay Barcode",
+            "Forward Primer Pad",
+            "Forward Primer Linker",
+            "515FB Forward Primer (Parada)",
+            "Primer For PCR",
+            "sample sheet Sample_ID",
+        ]
+
+        data1 = [
+            [
+                "X00180471",
+                "A",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_UK",
+                "THDMI_10317_UK2-US6",
+                "A1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "A1",
+                "515rcbc0",
+                "AATGATACGGCGACCACCGAGATCTACACGCT",
+                "AGCCTTCGTCGC",
+                "TATGGTAATT",
+                "GT",
+                "GTGYCAGCMGCCGCGGTAA",
+                (
+                    "AATGATACGGCGACCACCGAGATCTACACGCTAGCCTTCGTCGCT"
+                    "ATGGTAATTGTGTGYCAGCMGCCGCGGTAA"
+                ),
+                "X00180471",
+            ],
+            [
+                "X00180199",
+                "C",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_UK",
+                "THDMI_10317_UK2-US6",
+                "C1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "B1",
+                "515rcbc12",
+                "AATGATACGGCGACCACCGAGATCTACACGCT",
+                "CGTATAAATGCG",
+                "TATGGTAATT",
+                "GT",
+                "GTGYCAGCMGCCGCGGTAA",
+                (
+                    "AATGATACGGCGACCACCGAGATCTACACGCTCGTATAAATGCG"
+                    "TATGGTAATTGTGTGYCAGCMGCCGCGGTAA"
+                ),
+                "X00180199",
+            ],
+        ]
+
+        with self.assertRaisesRegex(ValueError, ""):
+            generate_qiita_prep_file(pd.DataFrame(columns=columns1,
+                                                  data=data1), "16S")
+
+    def test_generate_qiita_prep_file(self):
+        columns1 = [
+            "Sample",
+            "Row",
+            "Col",
+            "Blank",
+            "Project Plate",
+            "Compressed Plate Name",
+            "Well",
+            "Plate Position",
+            "Primer Plate #",
+            "Sample Plate",
+            "Project_Name",
+            "Plating",
+            "Extraction Kit Lot",
+            "Extraction Robot",
+            "TM1000 8 Tool",
+            "Primer Date",
+            "MasterMix Lot",
+            "Water Lot",
+            "Processing Robot",
+            "Original Name",
+            "Plate",
+            "EMP Primer Plate Well",
+            "Name",
+            "Illumina 5prime Adapter",
+            "Golay Barcode",
+            "Forward Primer Pad",
+            "Forward Primer Linker",
+            "515FB Forward Primer (Parada)",
+            "Primer For PCR",
+            "sample sheet Sample_ID",
+        ]
+        columns2 = [
+            "Sample",
+            "Row",
+            "Col",
+            "Blank",
+            "Project Plate",
+            "Compressed Plate Name",
+            "Well",
+            "Plate Position",
+            "Primer Plate #",
+            "Sample Plate",
+            "Project_Name",
+            "Plating",
+            "Extraction Kit Lot",
+            "Extraction Robot",
+            "TM1000 8 Tool",
+            "Primer Date",
+            "MasterMix Lot",
+            "Water Lot",
+            "Processing Robot",
+            "Original Name",
+            "Plate",
+            "EMP Primer Plate Well",
+            "Name",
+            "Reverse complement of 3prime Illumina Adapter",
+            "Golay Barcode",
+            "Reverse Primer Pad",
+            "Reverse Primer Linker",
+            "Reverse primer (EukBr)",
+            "Primer For PCR",
+            "sample sheet Sample_ID",
+        ]
+        columns3 = [
+            "Sample",
+            "Row",
+            "Col",
+            "Blank",
+            "Project Plate",
+            "Compressed Plate Name",
+            "Well",
+            "Plate Position",
+            "Primer Plate #",
+            "Sample Plate",
+            "Project_Name",
+            "Plating",
+            "Extraction Kit Lot",
+            "Extraction Robot",
+            "TM1000 8 Tool",
+            "Primer Date",
+            "MasterMix Lot",
+            "Water Lot",
+            "Processing Robot",
+            "Original Name",
+            "Plate",
+            "EMP Primer Plate Well",
+            "Name",
+            "Reverse complement of 3prime Illumina Adapter",
+            "Golay Barcode",
+            "Reverse Primer Pad",
+            "Reverse Primer Linker",
+            "ITS2 Reverse Primer",
+            "Primer For PCR",
+            "sample sheet Sample_ID",
+        ]
+
+        data1 = [
+            [
+                "X00180471",
+                "A",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_10317_UK2-US6",
+                "A1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "A1",
+                "515rcbc0",
+                "AATGATACGGCGACCACCGAGATCTACACGCT",
+                "AGCCTTCGTCGC",
+                "TATGGTAATT",
+                "GT",
+                "GTGYCAGCMGCCGCGGTAA",
+                (
+                    "AATGATACGGCGACCACCGAGATCTACACGCTAGCCTTCGTCGCT"
+                    "ATGGTAATTGTGTGYCAGCMGCCGCGGTAA"
+                ),
+                "X00180471",
+            ],
+            [
+                "X00180199",
+                "C",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_10317_UK2-US6",
+                "C1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "B1",
+                "515rcbc12",
+                "AATGATACGGCGACCACCGAGATCTACACGCT",
+                "CGTATAAATGCG",
+                "TATGGTAATT",
+                "GT",
+                "GTGYCAGCMGCCGCGGTAA",
+                (
+                    "AATGATACGGCGACCACCGAGATCTACACGCTCGTATAAATGCG"
+                    "TATGGTAATTGTGTGYCAGCMGCCGCGGTAA"
+                ),
+                "X00180199",
+            ],
+        ]
+
+        data2 = [
+            [
+                "X00180471",
+                "A",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_10317_UK2-US6",
+                "A1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "A1",
+                "EukBr_Hiseq_0017",
+                "CAAGCAGAAGACGGCATACGAGAT",
+                "ACGAGACTGATT",
+                "AGTCAGTCAG",
+                "CA",
+                "TGATCCTTCTGCAGGTTCACCTAC",
+                (
+                    "CAAGCAGAAGACGGCATACGAGATACGAGACTGATTAGTCAGTCAGCAT"
+                    "GATCCTTCTGCAGGTTCACCTAC"
+                ),
+                "X00180471",
+            ],
+            [
+                "X00180199",
+                "C",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_10317_UK2-US6",
+                "C1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "B1",
+                "EukBr_Hiseq_0029",
+                "CAAGCAGAAGACGGCATACGAGAT",
+                "GAATACCAAGTC",
+                "AGTCAGTCAG",
+                "CA",
+                "TGATCCTTCTGCAGGTTCACCTAC",
+                (
+                    "CAAGCAGAAGACGGCATACGAGATGAATACCAAGTCAGTCAGTCAGCAT"
+                    "GATCCTTCTGCAGGTTCACCTAC"
+                ),
+                "X00180199",
+            ],
+        ]
+
+        data3 = [
+            [
+                "X00180471",
+                "A",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_10317_UK2-US6",
+                "A1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "A1",
+                "kabir_ITS2rcbc0",
+                "CAAGCAGAAGACGGCATACGAGAT",
+                "TCCCTTGTCTCC",
+                "",
+                "CG",
+                "GCTGCGTTCTTCATCGATGC",
+                (
+                    "CAAGCAGAAGACGGCATACGAGATTCCCTTGTC"
+                    "TCCCGGCTGCGTTCTTCATCGATGC"
+                ),
+                "X00180471",
+            ],
+            [
+                "X00180199",
+                "C",
+                1,
+                False,
+                "THDMI_10317_PUK2",
+                "THDMI_10317_UK2-US6",
+                "C1",
+                "1",
+                "1",
+                "THDMI_UK_Plate_2",
+                "THDMI_UK",
+                "SF",
+                "166032128",
+                "Carmen_HOWE_KF3",
+                "109379Z",
+                "2021-08-17",
+                "978215",
+                "RNBJ0628",
+                "Echo550",
+                "",
+                "1",
+                "B1",
+                "kabir_ITS2rcbc12",
+                "CAAGCAGAAGACGGCATACGAGAT",
+                "TGCATACACTGG",
+                "",
+                "CG",
+                "GCTGCGTTCTTCATCGATGC",
+                (
+                    "CAAGCAGAAGACGGCATACGAGATTGCATACAC"
+                    "TGGCGGCTGCGTTCTTCATCGATGC"
+                ),
+                "X00180199",
+            ],
+        ]
+
+        self.platedf1 = pd.DataFrame(columns=columns1, data=data1)
+        self.platedf2 = pd.DataFrame(columns=columns2, data=data2)
+        self.platedf3 = pd.DataFrame(columns=columns3, data=data3)
+
+        obs1 = generate_qiita_prep_file(self.platedf1, '16S')
+        obs2 = generate_qiita_prep_file(self.platedf2, '18S')
+        obs3 = generate_qiita_prep_file(self.platedf3, 'ITS')
+
+        exp_columns1 = [
+            "sample_name",
+            "barcode",
+            "primer",
+            "primer_plate",
+            "well_id_384",
+            "plating",
+            "extractionkit_lot",
+            "extraction_robot",
+            "tm1000_8_tool",
+            "primer_date",
+            "mastermix_lot",
+            "water_lot",
+            "processing_robot",
+            "tm300_8_tool",
+            "tm50_8_tool",
+            "tm10_8_tool",
+            "sample_plate",
+            "project_name",
+            "orig_name",
+            "well_description",
+            "experiment_design_description",
+            "library_construction_protocol",
+            "linker",
+            "platform",
+            "run_center",
+            "run_date",
+            "run_prefix",
+            "pcr_primers",
+            "sequencing_meth",
+            "target_gene",
+            "target_subfragment",
+            "center_name",
+            "center_project_name",
+            "instrument_model",
+            "runid",
+            "sample sheet Sample_ID",
+        ]
+
+        exp_columns2 = [
+            "sample_name",
+            "barcode",
+            "primer",
+            "primer_plate",
+            "well_id_384",
+            "plating",
+            "extractionkit_lot",
+            "extraction_robot",
+            "tm1000_8_tool",
+            "primer_date",
+            "mastermix_lot",
+            "water_lot",
+            "processing_robot",
+            "tm300_8_tool",
+            "tm50_8_tool",
+            "tm10_8_tool",
+            "sample_plate",
+            "project_name",
+            "orig_name",
+            "well_description",
+            "experiment_design_description",
+            "library_construction_protocol",
+            "linker",
+            "platform",
+            "run_center",
+            "run_date",
+            "run_prefix",
+            "pcr_primers",
+            "sequencing_meth",
+            "target_gene",
+            "target_subfragment",
+            "center_name",
+            "center_project_name",
+            "instrument_model",
+            "runid",
+            "Reverse Primer Pad",
+            "Reverse primer (EukBr)",
+            "sample sheet Sample_ID",
+        ]
+
+        exp_columns3 = [
+            "sample_name",
+            "barcode",
+            "primer",
+            "primer_plate",
+            "well_id_384",
+            "plating",
+            "extractionkit_lot",
+            "extraction_robot",
+            "tm1000_8_tool",
+            "primer_date",
+            "mastermix_lot",
+            "water_lot",
+            "processing_robot",
+            "tm300_8_tool",
+            "tm50_8_tool",
+            "tm10_8_tool",
+            "sample_plate",
+            "project_name",
+            "orig_name",
+            "well_description",
+            "experiment_design_description",
+            "library_construction_protocol",
+            "linker",
+            "platform",
+            "run_center",
+            "run_date",
+            "run_prefix",
+            "pcr_primers",
+            "sequencing_meth",
+            "target_gene",
+            "target_subfragment",
+            "center_name",
+            "center_project_name",
+            "instrument_model",
+            "runid",
+            "ITS2 Reverse Primer",
+            "Reverse Primer Pad",
+            "sample sheet Sample_ID",
+        ]
+
+        exp1 = pd.DataFrame(
+            columns=exp_columns1,
+            data=[
+                [
+                    "X00180471",
+                    "AGCCTTCGTCGC",
+                    "GTGYCAGCMGCCGCGGTAA",
+                    "1",
+                    "A1",
+                    "SF",
+                    "166032128",
+                    "Carmen_HOWE_KF3",
+                    "109379Z",
+                    "2021-08-17",
+                    "978215",
+                    "RNBJ0628",
+                    "Echo550",
+                    "",
+                    "",
+                    "",
+                    "THDMI_UK_Plate_2",
+                    "THDMI_UK",
+                    "X00180471",
+                    "THDMI_UK_Plate_2.X00180471.A1",
+                    "",
+                    (
+                        "Illumina EMP protocol 515fbc, 806r "
+                        "amplification of 16S rRNA V4"
+                    ),
+                    "GT",
+                    "Illumina",
+                    "UCSDMI",
+                    "",
+                    "",
+                    ("FWD:GTGYCAGCMGCCGCGGTAA; " "REV:GGACTACNVGGGTWTCTAAT"),
+                    "Sequencing by synthesis",
+                    "16S rRNA",
+                    "V4",
+                    "UCSDMI",
+                    "",
+                    "",
+                    "",
+                    "X00180471",
+                ],
+                [
+                    "X00180199",
+                    "CGTATAAATGCG",
+                    "GTGYCAGCMGCCGCGGTAA",
+                    "1",
+                    "C1",
+                    "SF",
+                    "166032128",
+                    "Carmen_HOWE_KF3",
+                    "109379Z",
+                    "2021-08-17",
+                    "978215",
+                    "RNBJ0628",
+                    "Echo550",
+                    "",
+                    "",
+                    "",
+                    "THDMI_UK_Plate_2",
+                    "THDMI_UK",
+                    "X00180199",
+                    "THDMI_UK_Plate_2.X00180199.C1",
+                    "",
+                    (
+                        "Illumina EMP protocol 515fbc, "
+                        "806r amplification of 16S rRNA V4"
+                    ),
+                    "GT",
+                    "Illumina",
+                    "UCSDMI",
+                    "",
+                    "",
+                    ("FWD:GTGYCAGCMGCCGCGGTAA; " "REV:GGACTACNVGGGTWTCTAAT"),
+                    "Sequencing by synthesis",
+                    "16S rRNA",
+                    "V4",
+                    "UCSDMI",
+                    "",
+                    "",
+                    "",
+                    "X00180199",
+                ],
+            ],
+        )
+
+        exp2 = pd.DataFrame(
+            columns=exp_columns2,
+            data=[
+                [
+                    "X00180471",
+                    "ACGAGACTGATT",
+                    "CAAGCAGAAGACGGCATACGAGAT",
+                    "1",
+                    "A1",
+                    "SF",
+                    "166032128",
+                    "Carmen_HOWE_KF3",
+                    "109379Z",
+                    "2021-08-17",
+                    "978215",
+                    "RNBJ0628",
+                    "Echo550",
+                    "",
+                    "",
+                    "",
+                    "THDMI_UK_Plate_2",
+                    "THDMI_UK",
+                    "X00180471",
+                    "THDMI_UK_Plate_2.X00180471.A1",
+                    "",
+                    "Illumina EMP 18S rRNA 1391f EukBr",
+                    "CA",
+                    "Illumina",
+                    "UCSDMI",
+                    "",
+                    "",
+                    ("FWD:GTACACACCGCCCGTC; " "REV:TGATCCTTCTGCAGGTTCACCTAC"),
+                    "Sequencing by synthesis",
+                    "18S rRNA",
+                    "V9",
+                    "UCSDMI",
+                    "",
+                    "",
+                    "",
+                    "AGTCAGTCAG",
+                    "TGATCCTTCTGCAGGTTCACCTAC",
+                    "X00180471",
+                ],
+                [
+                    "X00180199",
+                    "GAATACCAAGTC",
+                    "CAAGCAGAAGACGGCATACGAGAT",
+                    "1",
+                    "C1",
+                    "SF",
+                    "166032128",
+                    "Carmen_HOWE_KF3",
+                    "109379Z",
+                    "2021-08-17",
+                    "978215",
+                    "RNBJ0628",
+                    "Echo550",
+                    "",
+                    "",
+                    "",
+                    "THDMI_UK_Plate_2",
+                    "THDMI_UK",
+                    "X00180199",
+                    "THDMI_UK_Plate_2.X00180199.C1",
+                    "",
+                    "Illumina EMP 18S rRNA 1391f EukBr",
+                    "CA",
+                    "Illumina",
+                    "UCSDMI",
+                    "",
+                    "",
+                    ("FWD:GTACACACCGCCCGTC; " "REV:TGATCCTTCTGCAGGTTCACCTAC"),
+                    "Sequencing by synthesis",
+                    "18S rRNA",
+                    "V9",
+                    "UCSDMI",
+                    "",
+                    "",
+                    "",
+                    "AGTCAGTCAG",
+                    "TGATCCTTCTGCAGGTTCACCTAC",
+                    "X00180199",
+                ],
+            ],
+        )
+
+        exp3 = pd.DataFrame(
+            columns=exp_columns3,
+            data=[
+                [
+                    "X00180471",
+                    "TCCCTTGTCTCC",
+                    "CAAGCAGAAGACGGCATACGAGAT",
+                    "1",
+                    "A1",
+                    "SF",
+                    "166032128",
+                    "Carmen_HOWE_KF3",
+                    "109379Z",
+                    "2021-08-17",
+                    "978215",
+                    "RNBJ0628",
+                    "Echo550",
+                    "",
+                    "",
+                    "",
+                    "THDMI_UK_Plate_2",
+                    "THDMI_UK",
+                    "X00180471",
+                    "THDMI_UK_Plate_2.X00180471.A1",
+                    "",
+                    (
+                        "Illumina  EMP protocol amplification of "
+                        "ITS1fbc, ITS2r"
+                    ),
+                    "CG",
+                    "Illumina",
+                    "UCSDMI",
+                    "",
+                    "",
+                    (
+                        "FWD:CTTGGTCATTTAGAGGAAGTAA; "
+                        "REV:GCTGCGTTCTTCATCGATGC"
+                    ),
+                    "Sequencing by synthesis",
+                    "ITS",
+                    "ITS_1_2",
+                    "UCSDMI",
+                    "",
+                    "",
+                    "",
+                    "GCTGCGTTCTTCATCGATGC",
+                    "",
+                    "X00180471",
+                ],
+                [
+                    "X00180199",
+                    "TGCATACACTGG",
+                    "CAAGCAGAAGACGGCATACGAGAT",
+                    "1",
+                    "C1",
+                    "SF",
+                    "166032128",
+                    "Carmen_HOWE_KF3",
+                    "109379Z",
+                    "2021-08-17",
+                    "978215",
+                    "RNBJ0628",
+                    "Echo550",
+                    "",
+                    "",
+                    "",
+                    "THDMI_UK_Plate_2",
+                    "THDMI_UK",
+                    "X00180199",
+                    "THDMI_UK_Plate_2.X00180199.C1",
+                    "",
+                    (
+                        "Illumina  EMP protocol amplification of "
+                        "ITS1fbc, ITS2r"
+                    ),
+                    "CG",
+                    "Illumina",
+                    "UCSDMI",
+                    "",
+                    "",
+                    (
+                        "FWD:CTTGGTCATTTAGAGGAAGTAA; "
+                        "REV:GCTGCGTTCTTCATCGATGC"
+                    ),
+                    "Sequencing by synthesis",
+                    "ITS",
+                    "ITS_1_2",
+                    "UCSDMI",
+                    "",
+                    "",
+                    "",
+                    "GCTGCGTTCTTCATCGATGC",
+                    "",
+                    "X00180199",
+                ],
+            ],
+        )
+
+        pd.testing.assert_frame_equal(obs1, exp1)
+        pd.testing.assert_frame_equal(obs2, exp2)
+        pd.testing.assert_frame_equal(obs3, exp3)
+
+    def test_qiita_scrub_name(self):
+        self.assertEqual(qiita_scrub_name('its my life'), 'its.my.life')
+        self.assertEqual(qiita_scrub_name('7-11.10()'), '7-11.10.')
+        self.assertEqual(qiita_scrub_name('{}/<>'), '.')
+        self.assertEqual(qiita_scrub_name('th!s.has.happened'),
+                         'th.s.has.happened')
+
+
+class TestPrePrepReplicates(TestCase):
+    def setUp(self):
+        self.data_dir = join('metapool', 'tests', 'data')
+        self.prep_w_replicates_path = join(self.data_dir,
+                                           'pre_prep_w_replicates.csv')
+        self.prep_wo_replicates_path = join(self.data_dir,
+                                            'pre_prep_wo_replicates.csv')
+        self.prep_legacy_path = join(self.data_dir, 'prep.tsv')
+        self.prep_w_mixed_replicates = join(self.data_dir,
+                                            'bad_pre_prep.csv')
+        self.replicate_output_paths = [join(self.data_dir,
+                                            'replicate_output5.txt'),
+                                       join(self.data_dir,
+                                            'replicate_output6.txt'),
+                                       join(self.data_dir,
+                                            'replicate_output7.txt')]
+
+    def test_pre_prep_needs_demuxing(self):
+        # Confirm that a pre-prep file w/contains_replicates column defined
+        # and containing replicate samples results in True being returned
+        # from pre_prep_needs_demuxing().
+        df = parse_prep(self.prep_w_replicates_path)
+        self.assertTrue(pre_prep_needs_demuxing(df))
+
+        # Confirm that a pre-prep file w/contains_replicates column defined
+        # and containing no replicate samples results in False being returned
+        # from pre_prep_needs_demuxing().
+        df = parse_prep(self.prep_wo_replicates_path)
+        self.assertFalse(pre_prep_needs_demuxing(df))
+
+        # Confirm that a legacy pre-prep file w/out contains_replicates
+        # column returns False from pre_prep_needs_demuxing().
+        df = parse_prep(self.prep_legacy_path)
+        self.assertFalse(pre_prep_needs_demuxing(df))
+
+        # Confirm that a pre-prep file w/contains_replicates column defined
+        # w/some samples expressing True while others are False returns an
+        # Error.
+        with self.assertRaisesRegex(ValueError, 'all values in contains_'
+                                                'replicates column must either'
+                                                ' be True or False'):
+            sheet = parse_prep(self.prep_w_mixed_replicates)
+            pre_prep_needs_demuxing(sheet)
+
+    def test_demux_pre_prep(self):
+        # parse_prep() extended to support pre-prep files as well.
+        df = parse_prep(self.prep_w_replicates_path)
+        results = demux_pre_prep(df)
+
+        # assert that the proper number of dataframes were returned.
+        self.assertEqual(len(results), 3)
+
+        # assert that each pre-prep dataframe appears in the correct order and
+        # matches known results.
+        for replicate_output_path, obs in zip(self.replicate_output_paths,
+                                              results):
+            print(f"testing against {replicate_output_path}...")
+            exp = parse_prep(replicate_output_path)
+            self.assertTrue(obs.equals(exp))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
All existing seqpro-related code clipped from metapool, as well as some of my new replacements.
A lot of code in seqpro is made more complex by the fact that it's not integrated into mg-scripts and it's interface is as a command-line tool.
Since SPP is the only user of seqpro, it makes sense to migrate all this code to mg-scripts so it can be simplified and leverage a number of functions in mg-scripts that perform similar tasks.
Performance will also be greatly improved.